### PR TITLE
✨ feat: add extremist party classification alerts

### DIFF
--- a/astro/src/components/ExtremistClassificationAlert.astro
+++ b/astro/src/components/ExtremistClassificationAlert.astro
@@ -1,0 +1,29 @@
+---
+type Props = {
+  extremistClassificationReason: string;
+  extremistClassificationSource: string;
+  extremistClassificationSourceUrl: string;
+};
+
+const {
+  extremistClassificationReason,
+  extremistClassificationSource,
+  extremistClassificationSourceUrl
+} = Astro.props as Props;
+---
+<div class="alert alert-soft alert-warning" role="alert">
+  <span class="iconify lucide--alert-triangle text-warning size-5"></span>
+  <div class="space-y-2">
+    <div>
+      {extremistClassificationReason}
+    </div>
+    <div class="text-base-content/70 text-xs">
+      Quelle:
+      <a
+        href={extremistClassificationSourceUrl}
+        target="_blank"
+        class="link"
+      >{extremistClassificationSource}</a>
+    </div>
+  </div>
+</div>

--- a/astro/src/models/registry.ts
+++ b/astro/src/models/registry.ts
@@ -27,6 +27,7 @@ export type RegistryParty = {
   id: string;
   name: string;
   seats: number;
+  additionalInformation?: { key: string; value: string }[];
 };
 
 export type RegistryPerson = {

--- a/astro/src/pages/pp/[parliamentPeriodId]/party/[partyId]/index.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/party/[partyId]/index.astro
@@ -7,6 +7,8 @@ import {
 import Councilors from './_councilors.astro';
 import Statistics from './_statistics.astro';
 import MetaTags from '@components/MetaTags.astro';
+import ExtremistClassificationAlert from '@components/ExtremistClassificationAlert.astro';
+import { extractExtremistClassificationInformation } from '@utils/party-utils';
 
 export const getStaticPaths = getParliamentPeriodWithPartyPaths;
 
@@ -31,6 +33,14 @@ const breadcrumbItems = [
     href: null
   }
 ];
+
+const {
+  extremistClassification,
+  extremistClassificationReason,
+  extremistClassificationSource,
+  extremistClassificationSourceUrl
+} = extractExtremistClassificationInformation(party);
+
 ---
 
 <PageLayout
@@ -39,6 +49,18 @@ const breadcrumbItems = [
   breadcrumbItems={breadcrumbItems}
 >
   <MetaTags slot="srw-meta-tags" partyName={party.name} />
+
+  {
+    extremistClassification && (
+      <div class="mb-4">
+        <ExtremistClassificationAlert
+          extremistClassificationReason={extremistClassificationReason}
+          extremistClassificationSource={extremistClassificationSource}
+          extremistClassificationSourceUrl={extremistClassificationSourceUrl}
+        />
+      </div>
+    )
+  }
 
   <div
     id="tabs"

--- a/astro/src/pages/pp/[parliamentPeriodId]/person/[personId]/index.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/person/[personId]/index.astro
@@ -8,6 +8,8 @@ import Statistics from './_statistics.astro';
 import VotingMatrix from './_voting-matrix.astro';
 import Speeches from './_speeches.astro';
 import MetaTags from '@components/MetaTags.astro';
+import ExtremistClassificationAlert from '@components/ExtremistClassificationAlert.astro';
+import { extractExtremistClassificationInformation } from '@utils/party-utils';
 
 export const getStaticPaths = getParliamentPeriodWithPersonPaths;
 
@@ -26,6 +28,14 @@ const party = parliamentPeriod.parties.find((party) => party.id === person.party
 if (!party) {
   throw new Error(`Party with ID ${person.partyId} not found in parliament period ${parliamentPeriodId}`);
 }
+
+const {
+  extremistClassification,
+  extremistClassificationReason,
+  extremistClassificationSource,
+  extremistClassificationSourceUrl
+} = extractExtremistClassificationInformation(party);
+
 ---
 <PageLayout
   parliamentPeriod={parliamentPeriod}
@@ -46,6 +56,18 @@ if (!party) {
   ]}
 >
   <MetaTags slot="srw-meta-tags" personName={person.name} />
+
+  {
+    extremistClassification && (
+      <div class="mb-4">
+        <ExtremistClassificationAlert
+          extremistClassificationReason={extremistClassificationReason}
+          extremistClassificationSource={extremistClassificationSource}
+          extremistClassificationSourceUrl={extremistClassificationSourceUrl}
+        />
+      </div>
+    )
+  }
 
   <div slot="sub-page-header">
     <div class="flex flex-row flex-wrap text-base-content/60 text-sm gap-x-4">

--- a/astro/src/utils/party-utils.ts
+++ b/astro/src/utils/party-utils.ts
@@ -1,0 +1,16 @@
+import type { RegistryParty } from '@models/registry.ts';
+
+export function extractExtremistClassificationInformation(party: RegistryParty) {
+  const additionalInformation = party.additionalInformation || [];
+  const extremistClassification = additionalInformation.find(i => i.key === 'EXTREMIST_CLASSIFICATION')?.value || null;
+  const extremistClassificationReason = additionalInformation.find(i => i.key === 'EXTREMIST_CLASSIFICATION_REASON')?.value || null;
+  const extremistClassificationSource = additionalInformation.find(i => i.key === 'EXTREMIST_CLASSIFICATION_SOURCE')?.value || null;
+  const extremistClassificationSourceUrl = additionalInformation.find(i => i.key === 'EXTREMIST_CLASSIFICATION_SOURCE_URL')?.value || null;
+
+  return {
+    extremistClassification,
+    extremistClassificationReason,
+    extremistClassificationSource,
+    extremistClassificationSourceUrl
+  };
+}

--- a/data/magdeburg-7/registry.json
+++ b/data/magdeburg-7/registry.json
@@ -350,7 +350,25 @@
     {
       "id": "afd",
       "name": "AfD",
-      "seats": 8
+      "seats": 8,
+      "additionalInformation": [
+        {
+          "key": "EXTREMIST_CLASSIFICATION",
+          "value": "RIGHT_WING"
+        },
+        {
+          "key": "EXTREMIST_CLASSIFICATION_REASON",
+          "value": "Der Verfassungsschutz Sachsen-Anhalt hat den Landesverband der AfD am 7. November 2023 als gesichert rechtsextremistisch eingestuft."
+        },
+        {
+          "key": "EXTREMIST_CLASSIFICATION_SOURCE",
+          "value": "Verfassungsschutz Sachsen-Anhalt"
+        },
+        {
+          "key": "EXTREMIST_CLASSIFICATION_SOURCE_URL",
+          "value": "https://mi.sachsen-anhalt.de/verfassungsschutz/themenfelder/rechtsextremismus/rechtsextremistische-parteien"
+        }
+      ]
     },
     {
       "id": "die-linke",

--- a/data/magdeburg-8/registry.json
+++ b/data/magdeburg-8/registry.json
@@ -207,7 +207,25 @@
     {
       "id": "afd",
       "name": "AfD",
-      "seats": 13
+      "seats": 13,
+      "additionalInformation": [
+        {
+          "key": "EXTREMIST_CLASSIFICATION",
+          "value": "RIGHT_WING"
+        },
+        {
+          "key": "EXTREMIST_CLASSIFICATION_REASON",
+          "value": "Der Verfassungsschutz Sachsen-Anhalt hat den Landesverband der AfD am 7. November 2023 als gesichert rechtsextremistisch eingestuft."
+        },
+        {
+          "key": "EXTREMIST_CLASSIFICATION_SOURCE",
+          "value": "Verfassungsschutz Sachsen-Anhalt"
+        },
+        {
+          "key": "EXTREMIST_CLASSIFICATION_SOURCE_URL",
+          "value": "https://mi.sachsen-anhalt.de/verfassungsschutz/themenfelder/rechtsextremismus/rechtsextremistische-parteien"
+        }
+      ]
     },
     {
       "id": "spd",


### PR DESCRIPTION
Implement warning system to identify and alert users about parties classified as extremist by constitutional protection agencies. Adds visual alerts on party and person pages with official source attribution.

- Add ExtremistClassificationAlert component with warning styling
- Extend registry model to support additional party information
- Create utility functions for extracting classification data
- Integrate alerts on party and person detail pages
- Mark AfD as right-wing extremist per Verfassungsschutz Sachsen-Anhalt classification