### PR TITLE
feat: consume voting-paper-map derivate, drop 3 raw OParl collections

### DIFF
--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -5,6 +5,18 @@ import tailwindcss from '@tailwindcss/vite';
 
 import sitemap from '@astrojs/sitemap';
 
+import { validateVotingPaperMapConsistency } from './src/content-validation/voting-paper-map-consistency.ts';
+
+/** @type {import('astro').AstroIntegration} */
+const validateOparlDerivates = {
+  name: 'validate-oparl-derivates',
+  hooks: {
+    'astro:config:setup': () => {
+      validateVotingPaperMapConsistency();
+    },
+  },
+};
+
 export default defineConfig({
   site: 'https://www.stadtratwatch.de',
   env: {
@@ -48,7 +60,7 @@ export default defineConfig({
     },
   },
 
-  integrations: [alpinejs(), sitemap()],
+  integrations: [alpinejs(), sitemap(), validateOparlDerivates],
 
   vite: {
     plugins: [tailwindcss()],

--- a/astro/src/content-validation/voting-paper-map-consistency.test.ts
+++ b/astro/src/content-validation/voting-paper-map-consistency.test.ts
@@ -1,0 +1,98 @@
+import { assert, describe, expect, test } from 'vitest';
+import {
+  assertVotingPaperMapConsistency,
+  collectVotingPaperMapInconsistencies,
+  type PeriodConsistencyInput,
+} from './voting-paper-map-consistency.ts';
+
+describe('collectVotingPaperMapInconsistencies', () => {
+  test('returns no inconsistencies when every map session exists in the registry', () => {
+    const periods: PeriodConsistencyInput[] = [
+      {
+        periodId: 'magdeburg-7',
+        registrySessionDates: ['2022-09-01', '2022-10-06'],
+        votingPaperMapSessionKeys: ['2022-09-01'],
+      },
+    ];
+
+    assert.deepEqual(collectVotingPaperMapInconsistencies(periods), []);
+  });
+
+  test('allows registry sessions that are absent from the map (forward direction only)', () => {
+    const periods: PeriodConsistencyInput[] = [
+      {
+        periodId: 'magdeburg-7',
+        registrySessionDates: ['2022-09-01', '2022-10-06'],
+        votingPaperMapSessionKeys: [],
+      },
+    ];
+
+    assert.deepEqual(collectVotingPaperMapInconsistencies(periods), []);
+  });
+
+  test('reports a map session that is missing from the registry', () => {
+    const periods: PeriodConsistencyInput[] = [
+      {
+        periodId: 'magdeburg-7',
+        registrySessionDates: ['2022-09-01'],
+        votingPaperMapSessionKeys: ['2022-09-01', '2099-01-01'],
+      },
+    ];
+
+    const inconsistencies = collectVotingPaperMapInconsistencies(periods);
+
+    assert.deepEqual(inconsistencies, [
+      'Session 2099-01-01 in voting-paper-map is missing from registry of period magdeburg-7',
+    ]);
+  });
+
+  test('collects all inconsistencies across periods instead of stopping at the first', () => {
+    const periods: PeriodConsistencyInput[] = [
+      {
+        periodId: 'magdeburg-7',
+        registrySessionDates: ['2022-09-01'],
+        votingPaperMapSessionKeys: ['2099-01-01'],
+      },
+      {
+        periodId: 'magdeburg-8',
+        registrySessionDates: ['2024-08-01'],
+        votingPaperMapSessionKeys: ['2099-02-02'],
+      },
+    ];
+
+    assert.lengthOf(collectVotingPaperMapInconsistencies(periods), 2);
+  });
+});
+
+describe('assertVotingPaperMapConsistency', () => {
+  test('does not throw when everything is consistent', () => {
+    const periods: PeriodConsistencyInput[] = [
+      {
+        periodId: 'magdeburg-7',
+        registrySessionDates: ['2022-09-01'],
+        votingPaperMapSessionKeys: ['2022-09-01'],
+      },
+    ];
+
+    expect(() => assertVotingPaperMapConsistency(periods)).not.toThrow();
+  });
+
+  test('fails fast with a bundled message listing every inconsistency', () => {
+    const periods: PeriodConsistencyInput[] = [
+      {
+        periodId: 'magdeburg-7',
+        registrySessionDates: ['2022-09-01'],
+        votingPaperMapSessionKeys: ['2099-01-01'],
+      },
+      {
+        periodId: 'magdeburg-8',
+        registrySessionDates: ['2024-08-01'],
+        votingPaperMapSessionKeys: ['2099-02-02'],
+      },
+    ];
+
+    expect(() => assertVotingPaperMapConsistency(periods)).toThrow(
+      /2 issue\(s\)[\s\S]*2099-01-01[\s\S]*2099-02-02/,
+    );
+  });
+});

--- a/astro/src/content-validation/voting-paper-map-consistency.ts
+++ b/astro/src/content-validation/voting-paper-map-consistency.ts
@@ -1,0 +1,90 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Registry } from '@models/registry.ts';
+import type { VotingPaperMap } from '@models/oparl-derivatives.ts';
+
+// Forward direction only: a registry session may legitimately be absent from the
+// derivate (a session can have no paper-linked votings), so the reverse is not an error.
+
+export type PeriodConsistencyInput = {
+  periodId: string;
+  registrySessionDates: string[];
+  votingPaperMapSessionKeys: string[];
+};
+
+export function collectVotingPaperMapInconsistencies(
+  periods: PeriodConsistencyInput[],
+): string[] {
+  const inconsistencies: string[] = [];
+  for (const period of periods) {
+    const knownSessionDates = new Set(period.registrySessionDates);
+    for (const sessionKey of period.votingPaperMapSessionKeys) {
+      if (!knownSessionDates.has(sessionKey)) {
+        inconsistencies.push(
+          `Session ${sessionKey} in voting-paper-map is missing from registry of period ${period.periodId}`,
+        );
+      }
+    }
+  }
+  return inconsistencies;
+}
+
+export function assertVotingPaperMapConsistency(
+  periods: PeriodConsistencyInput[],
+): void {
+  const inconsistencies = collectVotingPaperMapInconsistencies(periods);
+  if (inconsistencies.length > 0) {
+    throw new Error(
+      `voting-paper-map consistency check failed with ${inconsistencies.length} issue(s):\n` +
+        inconsistencies.map((issue) => `  - ${issue}`).join('\n'),
+    );
+  }
+}
+
+export function validateVotingPaperMapConsistency(
+  dataDir = defaultDataDir(),
+): void {
+  assertVotingPaperMapConsistency(readPeriodsFromDisk(dataDir));
+}
+
+function defaultDataDir(): string {
+  return path.resolve(process.cwd(), '..', 'data');
+}
+
+function readPeriodsFromDisk(dataDir: string): PeriodConsistencyInput[] {
+  return fs
+    .readdirSync(dataDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(dataDir, entry.name))
+    .filter((periodDir) => fs.existsSync(path.join(periodDir, 'registry.json')))
+    .map((periodDir) => readPeriod(periodDir));
+}
+
+function readPeriod(periodDir: string): PeriodConsistencyInput {
+  const registry = readJsonFile<Registry>(
+    path.join(periodDir, 'registry.json'),
+    periodDir,
+  );
+
+  const votingPaperMapPath = path.join(periodDir, 'voting-paper-map.json');
+  const votingPaperMap: VotingPaperMap = fs.existsSync(votingPaperMapPath)
+    ? readJsonFile<VotingPaperMap>(votingPaperMapPath, periodDir)
+    : {};
+
+  return {
+    periodId: registry.id,
+    registrySessionDates: registry.sessions.map((session) => session.date),
+    votingPaperMapSessionKeys: Object.keys(votingPaperMap),
+  };
+}
+
+function readJsonFile<T>(filePath: string, periodDir: string): T {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+  } catch (cause) {
+    throw new Error(
+      `Failed to read ${filePath} while validating period ${periodDir}`,
+      { cause },
+    );
+  }
+}

--- a/astro/src/content-validation/voting-paper-map-consistency.ts
+++ b/astro/src/content-validation/voting-paper-map-consistency.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Registry } from '@models/registry.ts';
 import type { VotingPaperMap } from '@models/oparl-derivatives.ts';
 
@@ -48,7 +49,8 @@ export function validateVotingPaperMapConsistency(
 }
 
 function defaultDataDir(): string {
-  return path.resolve(process.cwd(), '..', 'data');
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(moduleDir, '..', '..', '..', 'data');
 }
 
 function readPeriodsFromDisk(dataDir: string): PeriodConsistencyInput[] {

--- a/astro/src/content.config.ts
+++ b/astro/src/content.config.ts
@@ -4,12 +4,8 @@ import type { Registry } from '@models/registry.ts';
 import type { SessionScan } from '@models/session-scan.ts';
 import type { SessionSpeech } from '@models/session-speech.ts';
 import * as fs from 'node:fs';
-import type {
-  OparlAgendaItem,
-  OparlConsultation,
-  OparlMeeting,
-  OparlPaper,
-} from '@models/oparl.ts';
+import type { OparlPaper } from '@models/oparl.ts';
+import { votingPaperMapSchema } from '@models/oparl-derivatives.schema.ts';
 import { z } from 'astro/zod';
 
 const parliamentPeriods = defineCollection({
@@ -45,28 +41,13 @@ const sessionSpeeches = defineCollection({
   schema: z.array(z.custom<SessionSpeech>()),
 });
 
-const oparlMeetings = defineCollection({
-  loader: () =>
-    JSON.parse(
-      fs.readFileSync('../data/oparl-magdeburg/meetings.json', 'utf8'),
-    ) as OparlMeeting[],
-  schema: z.custom<OparlMeeting>(),
-});
-
-const oparlAgendaItems = defineCollection({
-  loader: () =>
-    JSON.parse(
-      fs.readFileSync('../data/oparl-magdeburg/agenda-items.json', 'utf8'),
-    ) as OparlAgendaItem[],
-  schema: z.custom<OparlAgendaItem>(),
-});
-
-const oparlConsultations = defineCollection({
-  loader: () =>
-    JSON.parse(
-      fs.readFileSync('../data/oparl-magdeburg/consultations.json', 'utf8'),
-    ) as OparlConsultation[],
-  schema: z.custom<OparlConsultation>(),
+const votingPaperMaps = defineCollection({
+  loader: glob({
+    pattern: '**/voting-paper-map.json',
+    base: '../data',
+    generateId: (options) => options.entry.split('/')[0],
+  }),
+  schema: votingPaperMapSchema,
 });
 
 const oparlPapers = defineCollection({
@@ -81,8 +62,6 @@ export const collections = {
   parliamentPeriods,
   sessionScans,
   sessionSpeeches,
-  oparlMeetings,
-  oparlAgendaItems,
-  oparlConsultations,
+  votingPaperMaps,
   oparlPapers,
 };

--- a/astro/src/pages/pp/[parliamentPeriodId]/_helpers.ts
+++ b/astro/src/pages/pp/[parliamentPeriodId]/_helpers.ts
@@ -4,33 +4,12 @@ import type { SessionInput } from '@models/SessionInput';
 
 const getParliamentPeriodStaticPaths = (async () => {
   const parliamentPeriods = await getCollection('parliamentPeriods');
-  const oparlMeetings = (await getCollection('oparlMeetings')).filter(
-    (meeting) =>
-      meeting.data.organization?.includes(
-        'https://ratsinfo.magdeburg.de/oparl/bodies/0001/organizations/gr/1',
-      ),
-  );
-  const oparlAgendaItems = (await getCollection('oparlAgendaItems')).filter(
-    (agendaItem) =>
-      agendaItem.data.meeting &&
-      oparlMeetings.some((meeting) => meeting.id === agendaItem.data.meeting),
-  );
-  const oparlConsultations = (await getCollection('oparlConsultations')).filter(
-    (consultation) =>
-      consultation.data.meeting &&
-      oparlMeetings.some((meeting) => meeting.id === consultation.data.meeting),
-  );
 
   return parliamentPeriods.map((parliamentPeriod) => {
     return {
       params: { parliamentPeriodId: parliamentPeriod.id },
       props: {
         parliamentPeriod: parliamentPeriod.data,
-        oparlMeetings: oparlMeetings.map((meeting) => meeting.data),
-        oparlAgendaItems: oparlAgendaItems.map((agendaItem) => agendaItem.data),
-        oparlConsultations: oparlConsultations.map(
-          (consultation) => consultation.data,
-        ),
       },
     };
   });
@@ -82,15 +61,11 @@ export const getParliamentPeriodWithSessionsPaths = (async () => {
         speeches,
       } as SessionInput;
     });
-    const { oparlMeetings, oparlAgendaItems, oparlConsultations } = path.props;
     return {
       params: { parliamentPeriodId: parliamentPeriod.id },
       props: {
         parliamentPeriod,
         sessionInputs,
-        oparlMeetings,
-        oparlAgendaItems,
-        oparlConsultations,
       },
     };
   });
@@ -104,13 +79,7 @@ export const getParliamentPeriodWithSessionPaths = async () => {
   const parliamentPeriodWithSessionsStaticPaths =
     await getParliamentPeriodWithSessionsPaths();
   return parliamentPeriodWithSessionsStaticPaths.flatMap((path) => {
-    const {
-      parliamentPeriod,
-      sessionInputs,
-      oparlMeetings,
-      oparlAgendaItems,
-      oparlConsultations,
-    } = path.props;
+    const { parliamentPeriod, sessionInputs } = path.props;
     return sessionInputs.map((sessionInput) => ({
       params: {
         parliamentPeriodId: parliamentPeriod.id,
@@ -119,9 +88,6 @@ export const getParliamentPeriodWithSessionPaths = async () => {
       props: {
         parliamentPeriod,
         sessionInput,
-        oparlMeetings,
-        oparlAgendaItems,
-        oparlConsultations,
       },
     }));
   });
@@ -135,13 +101,8 @@ export const getParliamentPeriodWithFactionPaths = async () => {
   const parliamentPeriodWithSessionsStaticPaths =
     await getParliamentPeriodWithSessionsPaths();
   return parliamentPeriodWithSessionsStaticPaths.flatMap((path) => {
-    const {
-      parliamentPeriod,
-      sessionInputs,
-      oparlMeetings,
-      oparlAgendaItems,
-      oparlConsultations,
-    } = path.props as ParliamentPeriodWithSessionsProps;
+    const { parliamentPeriod, sessionInputs } =
+      path.props as ParliamentPeriodWithSessionsProps;
     return parliamentPeriod.factions.map((faction) => ({
       params: {
         parliamentPeriodId: parliamentPeriod.id,
@@ -151,9 +112,6 @@ export const getParliamentPeriodWithFactionPaths = async () => {
         parliamentPeriod,
         faction,
         sessionInputs,
-        oparlMeetings,
-        oparlAgendaItems,
-        oparlConsultations,
       },
     }));
   });
@@ -186,13 +144,7 @@ export const getParliamentPeriodWithSessionAndVotingPaths = async () => {
   const paths = await getParliamentPeriodWithSessionPaths();
 
   return paths.flatMap((path) => {
-    const {
-      parliamentPeriod,
-      sessionInput,
-      oparlMeetings,
-      oparlAgendaItems,
-      oparlConsultations,
-    } = path.props;
+    const { parliamentPeriod, sessionInput } = path.props;
 
     return sessionInput.votings.map((voting) => {
       return {
@@ -204,9 +156,6 @@ export const getParliamentPeriodWithSessionAndVotingPaths = async () => {
         props: {
           parliamentPeriod,
           sessionInput,
-          oparlMeetings,
-          oparlAgendaItems,
-          oparlConsultations,
           voting,
         },
       };

--- a/astro/src/pages/pp/[parliamentPeriodId]/_helpers2.ts
+++ b/astro/src/pages/pp/[parliamentPeriodId]/_helpers2.ts
@@ -1,5 +1,6 @@
 import type { SessionScanItem } from '@models/session-scan';
 import type { VotingPaperMap } from '@models/oparl-derivatives.ts';
+import { getEntry } from 'astro:content';
 
 export function getPaperId(
   votingPaperMap: VotingPaperMap,
@@ -7,4 +8,10 @@ export function getPaperId(
   voting: SessionScanItem,
 ): number | null {
   return votingPaperMap[sessionDate]?.[voting.votingSubject.agendaItem] ?? null;
+}
+
+export async function getVotingPaperMap(
+  parliamentPeriodId: string,
+): Promise<VotingPaperMap> {
+  return (await getEntry('votingPaperMaps', parliamentPeriodId))?.data ?? {};
 }

--- a/astro/src/pages/pp/[parliamentPeriodId]/_helpers2.ts
+++ b/astro/src/pages/pp/[parliamentPeriodId]/_helpers2.ts
@@ -7,7 +7,15 @@ export function getPaperId(
   sessionDate: string,
   voting: SessionScanItem,
 ): number | null {
-  return votingPaperMap[sessionDate]?.[voting.votingSubject.agendaItem] ?? null;
+  const paperId =
+    votingPaperMap[sessionDate]?.[voting.votingSubject.agendaItem];
+  if (paperId === undefined) {
+    console.warn(
+      `No paperId found in voting-paper-map for session ${sessionDate}, agendaItem ${voting.votingSubject.agendaItem}`,
+    );
+    return null;
+  }
+  return paperId;
 }
 
 export async function getVotingPaperMap(

--- a/astro/src/pages/pp/[parliamentPeriodId]/_helpers2.ts
+++ b/astro/src/pages/pp/[parliamentPeriodId]/_helpers2.ts
@@ -1,54 +1,10 @@
 import type { SessionScanItem } from '@models/session-scan';
-import type {
-  OparlAgendaItem,
-  OparlConsultation,
-  OparlMeeting,
-} from '@models/oparl';
+import type { VotingPaperMap } from '@models/oparl-derivatives.ts';
 
 export function getPaperId(
+  votingPaperMap: VotingPaperMap,
   sessionDate: string,
   voting: SessionScanItem,
-  meetings: OparlMeeting[],
-  agendaItems: OparlAgendaItem[],
-  consultations: OparlConsultation[],
 ): number | null {
-  const meeting = meetings.find(
-    (meeting) => meeting.start && meeting.start.slice(0, 10) === sessionDate,
-  );
-  if (!meeting) {
-    console.warn('No OParl meeting found for session', sessionDate);
-  }
-
-  const agendaItem = agendaItems.find(
-    (agendaItem) =>
-      agendaItem.meeting &&
-      agendaItem.meeting === meeting?.id &&
-      agendaItem.number &&
-      agendaItem.number === voting.votingSubject.agendaItem,
-  );
-  if (!agendaItem) {
-    console.warn(
-      'No OParl agenda item found for voting',
-      sessionDate,
-      voting.votingSubject.agendaItem,
-    );
-
-    return null;
-  }
-
-  const consultation = consultations.find(
-    (consultation) => consultation.id === agendaItem.consultation,
-  );
-  if (!consultation) {
-    console.warn('No OParl consultation found for agenda item', agendaItem.id);
-
-    return null;
-  }
-
-  if (!consultation.paper) {
-    console.warn('No paper found for consultation', consultation.id);
-    return null;
-  }
-
-  return +consultation.paper.split('/').pop()!;
+  return votingPaperMap[sessionDate]?.[voting.votingSubject.agendaItem] ?? null;
 }

--- a/astro/src/pages/pp/[parliamentPeriodId]/faction/[factionId]/_motions.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/faction/[factionId]/_motions.astro
@@ -3,11 +3,7 @@ import { type SessionInput } from '@models/SessionInput';
 import { type RegistryFaction } from '@models/registry';
 import { getMotionResult, getVotingId, getVotingResult } from './_helpers';
 import { formatDate } from '@utils/format-date';
-import type {
-  OparlAgendaItem,
-  OparlMeeting,
-  OparlConsultation,
-} from '@models/oparl.ts';
+import type { VotingPaperMap } from '@models/oparl-derivatives.ts';
 import { getPaperId } from '../../_helpers2';
 
 export type MotionListItem = {
@@ -26,19 +22,11 @@ type Props = {
   parliamentPeriodId: string;
   faction: RegistryFaction;
   sessionInputs: SessionInput[];
-  oparlMeetings: OparlMeeting[];
-  oparlAgendaItems: OparlAgendaItem[];
-  oparlConsultations: OparlConsultation[];
+  votingPaperMap: VotingPaperMap;
 };
 
-const {
-  parliamentPeriodId,
-  faction,
-  sessionInputs,
-  oparlMeetings,
-  oparlAgendaItems,
-  oparlConsultations,
-} = Astro.props as Props;
+const { parliamentPeriodId, faction, sessionInputs, votingPaperMap } =
+  Astro.props as Props;
 
 const factionMotionVotings = sessionInputs
   .flatMap((sessionInput) =>
@@ -66,11 +54,9 @@ const motions = Array.from(motionsMap)
     const sessionId = motionVoting.sessionId;
     const sessionDate = motionVoting.sessionDate;
     const paperId = getPaperId(
+      votingPaperMap,
       motionVoting.sessionDate,
       motionVoting.voting,
-      oparlMeetings,
-      oparlAgendaItems,
-      oparlConsultations,
     );
     const votings = motionVotings.map((motionVoting) => ({
       votingId: +motionVoting.voting.votingFilename.substring(11, 14),

--- a/astro/src/pages/pp/[parliamentPeriodId]/faction/[factionId]/index.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/faction/[factionId]/index.astro
@@ -1,6 +1,5 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
-import { getEntry } from 'astro:content';
 import {
   type ParliamentPeriodWithFactionProps,
   getParliamentPeriodWithFactionPaths,
@@ -9,6 +8,7 @@ import Councilors from './_councilors.astro';
 import Motions from './_motions.astro';
 import Statistics from './_statistics.astro';
 import MetaTags from '@components/MetaTags.astro';
+import { getVotingPaperMap } from '../../_helpers2.ts';
 
 export const getStaticPaths = getParliamentPeriodWithFactionPaths;
 
@@ -16,8 +16,7 @@ const { parliamentPeriodId, factionId } = Astro.params;
 const { parliamentPeriod, faction, sessionInputs } =
   Astro.props as ParliamentPeriodWithFactionProps;
 
-const votingPaperMap =
-  (await getEntry('votingPaperMaps', parliamentPeriod.id))?.data ?? {};
+const votingPaperMap = await getVotingPaperMap(parliamentPeriod.id);
 
 const breadcrumbItems = [
   {

--- a/astro/src/pages/pp/[parliamentPeriodId]/faction/[factionId]/index.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/faction/[factionId]/index.astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
+import { getEntry } from 'astro:content';
 import {
   type ParliamentPeriodWithFactionProps,
   getParliamentPeriodWithFactionPaths,
@@ -12,14 +13,11 @@ import MetaTags from '@components/MetaTags.astro';
 export const getStaticPaths = getParliamentPeriodWithFactionPaths;
 
 const { parliamentPeriodId, factionId } = Astro.params;
-const {
-  parliamentPeriod,
-  faction,
-  sessionInputs,
-  oparlMeetings,
-  oparlAgendaItems,
-  oparlConsultations,
-} = Astro.props as ParliamentPeriodWithFactionProps;
+const { parliamentPeriod, faction, sessionInputs } =
+  Astro.props as ParliamentPeriodWithFactionProps;
+
+const votingPaperMap =
+  (await getEntry('votingPaperMaps', parliamentPeriod.id))?.data ?? {};
 
 const breadcrumbItems = [
   {
@@ -79,9 +77,7 @@ const breadcrumbItems = [
         parliamentPeriodId={parliamentPeriodId}
         faction={faction}
         sessionInputs={sessionInputs}
-        oparlMeetings={oparlMeetings}
-        oparlAgendaItems={oparlAgendaItems}
-        oparlConsultations={oparlConsultations}
+        votingPaperMap={votingPaperMap}
       />
     </div>
 

--- a/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/voting/[votingId]/index.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/voting/[votingId]/index.astro
@@ -1,12 +1,11 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
 import { formatDate } from '@utils/format-date';
-import { getEntry } from 'astro:content';
 import {
   type ParliamentPeriodWithSessionAndVotingProps,
   getParliamentPeriodWithSessionAndVotingPaths,
 } from '../../../../_helpers';
-import { getPaperId } from '../../../../_helpers2';
+import { getPaperId, getVotingPaperMap } from '../../../../_helpers2';
 import MetaTags from '@components/MetaTags.astro';
 import { getVideoTimestampAsSeconds } from '@utils/session-utils';
 
@@ -16,8 +15,7 @@ const { parliamentPeriodId, sessionId, votingId } = Astro.params;
 const { parliamentPeriod, sessionInput, voting } =
   Astro.props as ParliamentPeriodWithSessionAndVotingProps;
 
-const votingPaperMap =
-  (await getEntry('votingPaperMaps', parliamentPeriod.id))?.data ?? {};
+const votingPaperMap = await getVotingPaperMap(parliamentPeriod.id);
 
 const breadcrumbItems = [
   {

--- a/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/voting/[votingId]/index.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/voting/[votingId]/index.astro
@@ -1,6 +1,7 @@
 ---
 import PageLayout from '@layouts/PageLayout.astro';
 import { formatDate } from '@utils/format-date';
+import { getEntry } from 'astro:content';
 import {
   type ParliamentPeriodWithSessionAndVotingProps,
   getParliamentPeriodWithSessionAndVotingPaths,
@@ -12,14 +13,11 @@ import { getVideoTimestampAsSeconds } from '@utils/session-utils';
 export const getStaticPaths = getParliamentPeriodWithSessionAndVotingPaths;
 
 const { parliamentPeriodId, sessionId, votingId } = Astro.params;
-const {
-  parliamentPeriod,
-  sessionInput,
-  voting,
-  oparlMeetings,
-  oparlAgendaItems,
-  oparlConsultations,
-} = Astro.props as ParliamentPeriodWithSessionAndVotingProps;
+const { parliamentPeriod, sessionInput, voting } =
+  Astro.props as ParliamentPeriodWithSessionAndVotingProps;
+
+const votingPaperMap =
+  (await getEntry('votingPaperMaps', parliamentPeriod.id))?.data ?? {};
 
 const breadcrumbItems = [
   {
@@ -76,13 +74,7 @@ const groupsSortedByVotes = Object.entries(votesGroupedByFaction).sort(
   (a, b) => b[1].length - a[1].length,
 );
 
-const paperId = getPaperId(
-  sessionInput.session.date,
-  voting,
-  oparlMeetings,
-  oparlAgendaItems,
-  oparlConsultations,
-);
+const paperId = getPaperId(votingPaperMap, sessionInput.session.date, voting);
 
 const youtubeUrl = `${sessionInput.session.youtubeUrl}?t=${getVideoTimestampAsSeconds(voting)}s`;
 


### PR DESCRIPTION
Migrate the Voting→Paper path onto the committed voting-paper-map.json derivate (OParl-Precompile Schritt A, #439).

- content.config.ts: add votingPaperMaps collection with the real Zod schema from oparl-derivatives.schema.ts; remove oparlMeetings, oparlAgendaItems and oparlConsultations (oparlPapers stays for Schritt B).
- getPaperId: replace the Meeting→AgendaItem→Consultation→paper join with a votingPaperMap[sessionDate][agendaItem] lookup; new signature without the three raw arrays; update both callers.
- Remove the raw-array props threading from _helpers.ts and the pass-through pages; consumers load the derivate via getEntry.
- Add a dedicated cross-file validation module wired into an astro:config:setup hook: every voting-paper-map session key must exist in the period registry (forward direction only); collects all inconsistencies, then fails fast.

Parity verified once (throwaway check): getPaperId derivate lookup matches the old raw join across all 3785 votings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voting paper map data support for motion and voting pages.
  * Replaced legacy meeting, agenda, and consultation lookups with direct paper-map references.

* **Bug Fixes**
  * Added build-time validation to detect voting sessions missing from the available registry data.
  * Validation now reports all inconsistencies together with clear error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->