### PR TITLE
feat: consume paper-index derivate, drop last raw OParl collection (#…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,6 @@ jobs:
         run: npm ci
         working-directory: astro
 
-      - name: Fetch OParl data
-        run: npm run fetch-oparl
-        working-directory: astro
-
       - name: Run Prettier format check
         run: npm run format:check
         working-directory: astro

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,11 @@ deno check src/         # Type-check code
 
 1. **OParl Ingestion** → scrape-oparl fetches parliamentary data from the city council's OParl API
 2. **Paper Assets** → generate-paper-assets converts OParl data to batched JSON format, download-paper-files fetches PDFs
-3. **Video Processing** → scan-voting-images extracts voting results via OCR, parse-speakers identifies speakers, speech-to-text transcribes using OpenAI
-4. **Asset Generation** → generate-image-assets creates voting visualization PNGs
-5. **Search Indexing** → index-search imports into Typesense for full-text search
-6. **Web Rendering** → Astro builds static pages using data/ directory
+3. **OParl Derivates** → generate-oparl-derivatives precompiles the raw OParl data into two small, committed build inputs (`data/paper-index.json`, `data/{period}/voting-paper-map.json`). The **web build reads only these derivates, never the raw `data/oparl-magdeburg/`**. Raw OParl is a maintainer-only input for regenerating the derivates (populated via `fetch-oparl`).
+4. **Video Processing** → scan-voting-images extracts voting results via OCR, parse-speakers identifies speakers, speech-to-text transcribes using OpenAI
+5. **Asset Generation** → generate-image-assets creates voting visualization PNGs
+6. **Search Indexing** → index-search imports into Typesense for full-text search
+7. **Web Rendering** → Astro builds static pages using data/ directory (committed derivates + session data)
 
 ### Data Storage
 
@@ -72,7 +73,9 @@ data/
 │       ├── session-speakers-*.json  # Speaker segments
 │       └── session-speeches-*.json  # Transcriptions
 ├── magdeburg-8/              # Parliament period 8 (2024-)
-├── oparl-magdeburg/          # Raw OParl API data
+├── oparl-magdeburg/          # Raw OParl API data (populated via `fetch-oparl`, not committed)
+├── paper-index.json          # OParl derivate: main papers
+├── {period}/voting-paper-map.json  # OParl derivate per period
 └── papers/                   # Paper metadata in batched JSON files
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,11 @@ deno check src/         # Type-check code
 
 1. **OParl Ingestion** → scrape-oparl fetches parliamentary data from the city council's OParl API
 2. **Paper Assets** → generate-paper-assets converts OParl data to batched JSON format, download-paper-files fetches PDFs
-3. **Video Processing** → scan-voting-images extracts voting results via OCR, parse-speakers identifies speakers, speech-to-text transcribes using OpenAI
-4. **Asset Generation** → generate-image-assets creates voting visualization PNGs
-5. **Search Indexing** → index-search imports into Typesense for full-text search
-6. **Web Rendering** → Astro builds static pages using data/ directory
+3. **OParl Derivates** → generate-oparl-derivatives precompiles the raw OParl data into two small, committed build inputs (`data/paper-index.json`, `data/{period}/voting-paper-map.json`). The **web build reads only these derivates, never the raw `data/oparl-magdeburg/`**. Raw OParl is a maintainer-only input for regenerating the derivates (populated via `fetch-oparl`).
+4. **Video Processing** → scan-voting-images extracts voting results via OCR, parse-speakers identifies speakers, speech-to-text transcribes using OpenAI
+5. **Asset Generation** → generate-image-assets creates voting visualization PNGs
+6. **Search Indexing** → index-search imports into Typesense for full-text search
+7. **Web Rendering** → Astro builds static pages using data/ directory (committed derivates + session data)
 
 ### Data Storage
 
@@ -72,7 +73,9 @@ data/
 │       ├── session-speakers-*.json  # Speaker segments
 │       └── session-speeches-*.json  # Transcriptions
 ├── magdeburg-8/              # Parliament period 8 (2024-)
-├── oparl-magdeburg/          # Raw OParl API data
+├── oparl-magdeburg/          # Raw OParl API data (populated via `fetch-oparl`, not committed)
+├── paper-index.json          # OParl derivate: main papers
+├── {period}/voting-paper-map.json  # OParl derivate per period
 └── papers/                   # Paper metadata in batched JSON files
 ```
 

--- a/astro/package.json
+++ b/astro/package.json
@@ -4,9 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "fetch-oparl": "node --env-file-if-exists=.env scripts/fetch-oparl/fetch-oparl.mjs",
-    "predev": "npm run fetch-oparl",
     "dev": "astro dev",
-    "prebuild": "npm run fetch-oparl",
     "build": "NODE_OPTIONS='--max-old-space-size=8192' astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/astro/src/content.config.ts
+++ b/astro/src/content.config.ts
@@ -4,8 +4,11 @@ import type { Registry } from '@models/registry.ts';
 import type { SessionScan } from '@models/session-scan.ts';
 import type { SessionSpeech } from '@models/session-speech.ts';
 import * as fs from 'node:fs';
-import type { OparlPaper } from '@models/oparl.ts';
-import { votingPaperMapSchema } from '@models/oparl-derivatives.schema.ts';
+import type { PaperIndex } from '@models/oparl-derivatives.ts';
+import {
+  paperIndexEntrySchema,
+  votingPaperMapSchema,
+} from '@models/oparl-derivatives.schema.ts';
 import { z } from 'astro/zod';
 
 const parliamentPeriods = defineCollection({
@@ -50,12 +53,12 @@ const votingPaperMaps = defineCollection({
   schema: votingPaperMapSchema,
 });
 
-const oparlPapers = defineCollection({
+const paperIndex = defineCollection({
   loader: () =>
     JSON.parse(
-      fs.readFileSync('../data/oparl-magdeburg/papers.json', 'utf8'),
-    ) as OparlPaper[],
-  schema: z.custom<OparlPaper>(),
+      fs.readFileSync('../data/paper-index.json', 'utf8'),
+    ) as PaperIndex,
+  schema: paperIndexEntrySchema,
 });
 
 export const collections = {
@@ -63,5 +66,5 @@ export const collections = {
   sessionScans,
   sessionSpeeches,
   votingPaperMaps,
-  oparlPapers,
+  paperIndex,
 };

--- a/astro/src/pages/papers/_helpers.test.ts
+++ b/astro/src/pages/papers/_helpers.test.ts
@@ -8,7 +8,17 @@ import {
   vi,
 } from 'vitest';
 import { getRecentMainPapers, getRecentPapersPeriod } from './_helpers.ts';
-import type { OparlPaper } from '@models/oparl.ts';
+import type { PaperIndexEntry } from '@models/oparl-derivatives.ts';
+
+function paperIndexEntry(
+  overrides: Partial<PaperIndexEntry> & Pick<PaperIndexEntry, 'id' | 'date'>,
+): PaperIndexEntry {
+  return {
+    oparlId: `https://example.com/oparl/papers/${overrides.id}`,
+    name: 'Paper',
+    ...overrides,
+  };
+}
 
 describe('getRecentMainPapers', () => {
   beforeAll(() => vi.useFakeTimers());
@@ -22,50 +32,15 @@ describe('getRecentMainPapers', () => {
     assert.deepEqual(result, []);
   });
 
-  test('filters out papers with subordinated papers', () => {
-    const papers: OparlPaper[] = [
-      {
-        id: 'https://example.com/oparl/paper-1',
-        type: 'paper',
-        name: 'Main Paper',
-        reference: 'M-001',
-        paperType: 'Antrag',
-        date: '2024-03-01',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'https://example.com/oparl/paper-2',
-        type: 'paper',
-        name: 'Paper with subordinates',
-        reference: 'M-002',
-        paperType: 'Antrag',
-        date: '2024-03-01',
-        subordinatedPaper: ['sub-paper-1'],
-      },
-    ];
-
-    const result = getRecentMainPapers(papers);
-
-    assert.lengthOf(result, 1);
-    assert.equal(result[0].id, 'paper-1');
-    assert.equal(result[0].oparlId, 'https://example.com/oparl/paper-1');
-    assert.equal(result[0].title, 'Main Paper');
-    assert.equal(result[0].reference, 'M-001');
-    assert.equal(result[0].type, 'Antrag');
-    assert.equal(result[0].date, '2024-03-01');
-    assert.equal(result[0].dateDisplay, '01.03.2024');
-  });
-
   test('returns RecentPaper objects with all required fields', () => {
-    const papers: OparlPaper[] = [
+    const papers: PaperIndexEntry[] = [
       {
-        id: 'https://example.com/oparl/papers/12345',
-        type: 'paper',
+        oparlId: 'https://example.com/oparl/papers/12345',
+        id: '12345',
         name: 'Test Paper Title',
         reference: 'A-123/2024',
         paperType: 'Antrag',
         date: '2024-03-10',
-        subordinatedPaper: [],
       },
     ];
 
@@ -74,26 +49,23 @@ describe('getRecentMainPapers', () => {
     assert.lengthOf(result, 1);
     const paper = result[0];
 
-    // Check all fields of RecentPaper
     assert.equal(paper.oparlId, 'https://example.com/oparl/papers/12345');
     assert.equal(paper.id, '12345');
     assert.equal(paper.date, '2024-03-10');
     assert.equal(paper.dateDisplay, '10.03.2024');
-    assert.equal(paper.type, 'Antrag');
+    assert.equal(paper.paperType, 'Antrag');
     assert.equal(paper.reference, 'A-123/2024');
-    assert.equal(paper.title, 'Test Paper Title');
+    assert.equal(paper.name, 'Test Paper Title');
   });
 
   test('handles papers with optional fields as undefined', () => {
-    const papers: OparlPaper[] = [
-      {
-        id: 'https://example.com/oparl/papers/67890',
-        type: 'paper',
+    const papers: PaperIndexEntry[] = [
+      paperIndexEntry({
+        id: '67890',
         name: 'Paper without optional fields',
         date: '2024-03-05',
-        subordinatedPaper: [],
         // paperType and reference are undefined
-      },
+      }),
     ];
 
     const result = getRecentMainPapers(papers);
@@ -101,59 +73,18 @@ describe('getRecentMainPapers', () => {
     assert.lengthOf(result, 1);
     const paper = result[0];
 
-    assert.equal(paper.type, undefined);
+    assert.equal(paper.paperType, undefined);
     assert.equal(paper.reference, undefined);
-    assert.equal(paper.title, 'Paper without optional fields');
-  });
-
-  test('filters out papers without a date', () => {
-    const papers: OparlPaper[] = [
-      {
-        id: 'paper-1',
-        type: 'paper',
-        name: 'Paper with date',
-        date: '2024-03-01',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-2',
-        type: 'paper',
-        name: 'Paper without date',
-        subordinatedPaper: [],
-      },
-    ];
-
-    const result = getRecentMainPapers(papers);
-
-    assert.lengthOf(result, 1);
-    assert.equal(result[0].id, 'paper-1');
+    assert.equal(paper.name, 'Paper without optional fields');
   });
 
   test('includes papers from the last 3 months (starting from first day of month 2 months ago)', () => {
     // Current date: 2024-03-15
     // Three months ago calculation: new Date(2024, 3-2, 1) = 2024-01-01
-    const papers: OparlPaper[] = [
-      {
-        id: 'paper-1',
-        type: 'paper',
-        name: 'Recent paper',
-        date: '2024-02-15',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-2',
-        type: 'paper',
-        name: 'Paper on boundary (included)',
-        date: '2024-01-01',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-3',
-        type: 'paper',
-        name: 'Old paper (excluded)',
-        date: '2023-12-31',
-        subordinatedPaper: [],
-      },
+    const papers: PaperIndexEntry[] = [
+      paperIndexEntry({ id: 'paper-1', date: '2024-02-15' }),
+      paperIndexEntry({ id: 'paper-2', date: '2024-01-01' }),
+      paperIndexEntry({ id: 'paper-3', date: '2023-12-31' }),
     ];
 
     const result = getRecentMainPapers(papers);
@@ -165,94 +96,13 @@ describe('getRecentMainPapers', () => {
     );
   });
 
-  test('handles papers with undefined subordinatedPaper field', () => {
-    const papers: OparlPaper[] = [
-      {
-        id: 'paper-1',
-        type: 'paper',
-        name: 'Paper without subordinatedPaper field',
-        date: '2024-03-01',
-      },
-    ];
-
-    const result = getRecentMainPapers(papers);
-
-    assert.lengthOf(result, 1);
-    assert.equal(result[0].id, 'paper-1');
-  });
-
-  test('applies all filters together', () => {
-    const papers: OparlPaper[] = [
-      {
-        id: 'paper-1',
-        type: 'paper',
-        name: 'Valid recent main paper',
-        date: '2024-02-15',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-2',
-        type: 'paper',
-        name: 'Has subordinates',
-        date: '2024-02-15',
-        subordinatedPaper: ['sub-1'],
-      },
-      {
-        id: 'paper-3',
-        type: 'paper',
-        name: 'No date',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-4',
-        type: 'paper',
-        name: 'Too old',
-        date: '2023-12-31',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-5',
-        type: 'paper',
-        name: 'Another valid paper',
-        date: '2024-01-01',
-        subordinatedPaper: [],
-      },
-    ];
-
-    const result = getRecentMainPapers(papers);
-
-    assert.lengthOf(result, 2);
-    assert.includeMembers(
-      result.map((p) => p.id),
-      ['paper-1', 'paper-5'],
-    );
-  });
-
   test('handles papers at month boundaries correctly', () => {
     // Current date: 2024-03-15
     // Cutoff: 2024-01-01
-    const papers: OparlPaper[] = [
-      {
-        id: 'paper-jan-1',
-        type: 'paper',
-        name: 'January 1st (included)',
-        date: '2024-01-01',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-dec-31',
-        type: 'paper',
-        name: 'December 31st (excluded)',
-        date: '2023-12-31',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-feb-29',
-        type: 'paper',
-        name: 'End of February (included)',
-        date: '2024-02-29',
-        subordinatedPaper: [],
-      },
+    const papers: PaperIndexEntry[] = [
+      paperIndexEntry({ id: 'paper-jan-1', date: '2024-01-01' }),
+      paperIndexEntry({ id: 'paper-dec-31', date: '2023-12-31' }),
+      paperIndexEntry({ id: 'paper-feb-29', date: '2024-02-29' }),
     ];
 
     const result = getRecentMainPapers(papers);
@@ -268,21 +118,9 @@ describe('getRecentMainPapers', () => {
     vi.setSystemTime(new Date('2024-03-01'));
     // Three months ago: new Date(2024, 3-2, 1) = 2024-01-01
 
-    const papers: OparlPaper[] = [
-      {
-        id: 'paper-1',
-        type: 'paper',
-        name: 'January paper',
-        date: '2024-01-15',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-2',
-        type: 'paper',
-        name: 'December paper',
-        date: '2023-12-15',
-        subordinatedPaper: [],
-      },
+    const papers: PaperIndexEntry[] = [
+      paperIndexEntry({ id: 'paper-1', date: '2024-01-15' }),
+      paperIndexEntry({ id: 'paper-2', date: '2023-12-15' }),
     ];
 
     const result = getRecentMainPapers(papers);
@@ -295,49 +133,15 @@ describe('getRecentMainPapers', () => {
     vi.setSystemTime(new Date('2024-03-31'));
     // Three months ago: new Date(2024, 3-2, 1) = 2024-01-01
 
-    const papers: OparlPaper[] = [
-      {
-        id: 'paper-1',
-        type: 'paper',
-        name: 'January paper',
-        date: '2024-01-01',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-2',
-        type: 'paper',
-        name: 'December paper',
-        date: '2023-12-31',
-        subordinatedPaper: [],
-      },
+    const papers: PaperIndexEntry[] = [
+      paperIndexEntry({ id: 'paper-1', date: '2024-01-01' }),
+      paperIndexEntry({ id: 'paper-2', date: '2023-12-31' }),
     ];
 
     const result = getRecentMainPapers(papers);
 
     assert.lengthOf(result, 1);
     assert.equal(result[0].id, 'paper-1');
-  });
-
-  test('handles empty subordinatedPaper array vs undefined correctly', () => {
-    const papers: OparlPaper[] = [
-      {
-        id: 'paper-1',
-        type: 'paper',
-        name: 'Empty array',
-        date: '2024-03-01',
-        subordinatedPaper: [],
-      },
-      {
-        id: 'paper-2',
-        type: 'paper',
-        name: 'Undefined field',
-        date: '2024-03-01',
-      },
-    ];
-
-    const result = getRecentMainPapers(papers);
-
-    assert.lengthOf(result, 2);
   });
 });
 

--- a/astro/src/pages/papers/_helpers.ts
+++ b/astro/src/pages/papers/_helpers.ts
@@ -1,23 +1,16 @@
-import type { OparlPaper } from '@models/oparl.ts';
+import type { PaperIndexEntry } from '@models/oparl-derivatives.ts';
 import type { RecentPaper } from './_models.ts';
 import { formatDate } from '@utils/format-date.ts';
 
-export function getRecentMainPapers(papers: OparlPaper[]): RecentPaper[] {
+export function getRecentMainPapers(papers: PaperIndexEntry[]): RecentPaper[] {
   const today = new Date();
   const threeMonthsAgo = new Date(today.getFullYear(), today.getMonth() - 2, 1);
 
   return papers
-    .filter((oparlPaper) => (oparlPaper.subordinatedPaper || []).length === 0)
-    .filter((oparlPaper) => !!oparlPaper.date)
-    .filter((oparlPaper) => new Date(oparlPaper.date!) >= threeMonthsAgo)
-    .map<RecentPaper>((oparlPaper) => ({
-      oparlId: oparlPaper.id,
-      id: oparlPaper.id.split('/').pop()!,
-      date: oparlPaper.date!,
-      dateDisplay: formatDate(oparlPaper.date!),
-      type: oparlPaper.paperType,
-      reference: oparlPaper.reference,
-      title: oparlPaper.name,
+    .filter((paper) => new Date(paper.date) >= threeMonthsAgo)
+    .map<RecentPaper>((paper) => ({
+      ...paper,
+      dateDisplay: formatDate(paper.date),
     }));
 }
 

--- a/astro/src/pages/papers/_models.ts
+++ b/astro/src/pages/papers/_models.ts
@@ -1,9 +1,5 @@
-export type RecentPaper = {
-  oparlId: string;
-  id: string;
-  date: string;
+import type { PaperIndexEntry } from '@models/oparl-derivatives.ts';
+
+export type RecentPaper = PaperIndexEntry & {
   dateDisplay: string;
-  type: string | undefined;
-  reference: string | undefined;
-  title: string;
 };

--- a/astro/src/pages/papers/index.astro
+++ b/astro/src/pages/papers/index.astro
@@ -3,8 +3,8 @@ import PageLayout from '@layouts/PageLayout.astro';
 import { getCollection } from 'astro:content';
 import { getRecentMainPapers, getRecentPapersPeriod } from './_helpers.ts';
 
-const oparlPapersCollection = await getCollection('oparlPapers');
-const allPapers = oparlPapersCollection.map((oparlPaper) => oparlPaper.data);
+const paperIndexCollection = await getCollection('paperIndex');
+const allPapers = paperIndexCollection.map((entry) => entry.data);
 const recentMainPapers = getRecentMainPapers(allPapers).toSorted((a, b) =>
   b.date.localeCompare(a.date),
 );
@@ -38,10 +38,10 @@ const pageTitle = getRecentPapersPeriod();
                     href={`/paper?paperId=${paper.id}`}
                     class="link link-primary"
                   >
-                    {paper.type || 'Drucksache'} {paper.reference || ''}
+                    {paper.paperType || 'Drucksache'} {paper.reference || ''}
                   </a>
                 </td>
-                <td>{paper.title}</td>
+                <td>{paper.name}</td>
               </tr>
             ))
           }

--- a/docs/arc42/05-bausteinsicht/01-ebene-1-gesamtsystem.adoc
+++ b/docs/arc42/05-bausteinsicht/01-ebene-1-gesamtsystem.adoc
@@ -84,6 +84,10 @@ data/
 │       └── session-speeches-*.json   # Transkripte
 ├── magdeburg-8/
 ├── oparl-magdeburg/              # rohe OParl-Daten (nicht im Repository;
-│                                 #   extern gehalten, zur Bauzeit geladen)
+│                                 #   extern gehalten, nur vom Maintainer für
+│                                 #   die Derivat-Erzeugung geladen — nicht vom
+│                                 #   Web-Build)
+├── paper-index.json             # committetes OParl-Derivat: Haupt-Drucksachen
+├── magdeburg-*/voting-paper-map.json  # committetes OParl-Derivat je Periode
 └── papers/                       # Drucksachen-Metadaten (JSON-Batches)
 ----

--- a/docs/arc42/06-laufzeitsicht/02-oparl-ingestion.adoc
+++ b/docs/arc42/06-laufzeitsicht/02-oparl-ingestion.adoc
@@ -8,6 +8,9 @@ aufbereitet werden. Quelle ist die standardisierte OParl-Schnittstelle der Stadt
 Der Ablauf ist eine Kette über die Datenablage: `scrape-oparl` legt die
 Rohdaten ab, `download-paper-files` lädt die verlinkten PDF-Dokumente, und
 `generate-paper-assets` überführt die Drucksachen in das ausgelieferte JSON-Format.
+Parallel dazu erzeugt `generate-oparl-derivatives` aus denselben Rohdaten die
+committeten OParl-Derivate (`paper-index.json`, `voting-paper-map.json`), die der
+Astro-Build konsumiert (siehe <<konzept-datenhaltung,Datenhaltung>>).
 Den Abschluss
 bildet `index-search` — diese Stufe gehört nicht allein zur OParl-Verarbeitung,
 sondern *führt zwei Pipelines zusammen*: Sie indiziert sowohl die hier
@@ -45,6 +48,14 @@ note right
   Ausgabe: data/papers/
 end note
 
+:**generate-oparl-derivatives** (Deno)\nOParl-Derivate erzeugen;
+note right
+  Eingabe: OParl-Rohdaten + registry.json
+  Ausgabe:
+  - data/paper-index.json
+  - data/{periode}/voting-paper-map.json
+end note
+
 :**index-search** (Deno)\nDrucksachen + Redebeiträge\nin Typesense importieren;
 note right
   Eingaben:
@@ -76,6 +87,11 @@ stop
 | *generate-paper-assets* (Deno)
 | OParl-Rohdaten + heruntergeladene PDFs (für die Dateigrößen)
 | Drucksachen-Metadaten als JSON-Batches in `data/papers/`
+
+| *generate-oparl-derivatives* (Deno)
+| OParl-Rohdaten + `registry.json` je Wahlperiode
+| OParl-Derivate: `data/paper-index.json` (global) und
+  `data/{periode}/voting-paper-map.json` (je Periode)
 
 | *index-search* (Deno)
 | `data/papers/` (aus dieser Pipeline) **und** `session-speeches-*.json` (aus der

--- a/docs/arc42/08-querschnittliche-konzepte/02-datenhaltung-und-versionierung.adoc
+++ b/docs/arc42/08-querschnittliche-konzepte/02-datenhaltung-und-versionierung.adoc
@@ -27,11 +27,20 @@ Große, generierte Binärdaten gehören nicht in das Repository. Abstimmungs-PNG
 
 Der OParl-Datenbestand (`data/oparl-magdeburg/`) ist umfangreich, wird bei jedem Scrape vollständig neu geschrieben und ist aus der OParl-Schnittstelle reproduzierbar. Er liegt daher *nicht im Repository*, sondern extern in AWS S3 unter dem Präfix `oparl/` und wird über CloudFront öffentlich ausgeliefert. Es wird genau ein „aktueller“ Snapshot gehalten: inhaltsadressierte, unveränderliche Blobs (`oparl/<datei>.<sha>.json.gz`) zusammen mit einer kleinen `manifest.json`. Weil die Blob-Namen inhaltsbasiert sind, ist nie eine CloudFront-Invalidierung nötig.
 
-Das Veröffentlichen ist ein optionaler, authentifizierter Abschlussschritt des Scrapers (`scrape-oparl --push`); das Laden (`fetch-oparl`) ist öffentlich und benötigt keine Zugangsdaten. Vor jedem Web-Build und Dev-Start lädt `fetch-oparl` den Snapshot anhand des Manifests in das lokale `data/oparl-magdeburg/` — automatisiert über die `prebuild`/`predev`-Hooks. Diese Entscheidung ist in <<adr-0005,ADR-0005>> festgehalten; sie betrifft nur die reproduzierbaren _OParl-Rohdaten_, während der verarbeitete Sitzungsbestand weiterhin versioniert im Repository bleibt (<<adr-0001,ADR-0001>>).
+Das Veröffentlichen ist ein optionaler, authentifizierter Abschlussschritt des Scrapers (`scrape-oparl --push`); das Laden (`fetch-oparl`) ist öffentlich und benötigt keine Zugangsdaten. `fetch-oparl` ist ein *Maintainer-Schritt*: Es lädt den Snapshot in das lokale `data/oparl-magdeburg/`, damit der Maintainer daraus die committeten OParl-Derivate regenerieren kann.
+
+== OParl-Precompile-Derivate
+
+Statt die rohen OParl-Daten direkt zu lesen, konsumiert der Web-Build zwei kleine, zweckgebundene und *committete* Derivate, die ein manueller Precompile-Schritt (`generate-oparl-derivatives`) aus den Rohdaten erzeugt:
+
+* `data/paper-index.json` (global) — projizierte Haupt-Drucksachen für die Drucksachen-Liste; der 3-Monats-Filter läuft weiterhin im Build.
+* `data/{periode}/voting-paper-map.json` (je Wahlperiode) — Abbildung Sitzung → Tagesordnungspunkt → Drucksachen-Id für den Voting→Paper-Bezug.
+
+Die Derivate werden mit stabiler Sortierung vollständig neu erzeugt (sauberer `git diff`) und ohne Zeitstempel committet. Ein Astro-Build-Hook prüft die Konsistenz (`voting-paper-map`-Sitzungen gegen die `registry.json`) und bricht bei Abweichung ab (fail fast).
 
 == Einlesen zur Bauzeit
 
-Die Web-Anwendung liest die Dateien der Datenablage zur Bauzeit über Astro _Content Collections_ (`glob`-Loader) typisiert ein. Damit wird der Dateibestand gegen die geteilten Modelle (siehe <<konzept-datenmodell,Fachliches Datenmodell>>) geprüft und steht den statischen Seiten strukturiert zur Verfügung.
+Die Web-Anwendung liest die Dateien der Datenablage — inklusive der committeten OParl-Derivate, aber *ohne* die rohen OParl-Daten — zur Bauzeit über Astro _Content Collections_ (`glob`-Loader) typisiert ein. Die Derivat-Collections nutzen echte Zod-Schemata, sodass ein strukturell abweichendes Derivat den Build abbricht. Damit wird der Dateibestand gegen die geteilten Modelle (siehe <<konzept-datenmodell,Fachliches Datenmodell>>) geprüft und steht den statischen Seiten strukturiert zur Verfügung.
 
 == Konfiguration & Umgebungen
 

--- a/docs/arc42/09-architekturentscheidungen/adr-0005-externe-oparl-rohdaten.adoc
+++ b/docs/arc42/09-architekturentscheidungen/adr-0005-externe-oparl-rohdaten.adoc
@@ -22,6 +22,11 @@ Der rohe OParl-Bestand wird *nicht mehr im Repository* gehalten (`data/oparl-mag
 
 Diese Entscheidung betrifft ausschließlich die reproduzierbaren _Rohdaten_. Der verarbeitete Sitzungsbestand (Abstimmungen, Reden, `registry.json`) bleibt weiterhin versioniert im Repository (<<adr-0001,ADR-0001>>).
 
+[NOTE]
+====
+*Ergänzung (OParl-Precompile):* Der Web-Build liest die rohen OParl-Daten inzwischen *nicht mehr* direkt. Ein manueller Precompile-Schritt (`generate-oparl-derivatives`) erzeugt aus den Rohdaten zwei kleine, committete Derivate (`paper-index.json`, `voting-paper-map.json`), die der Astro-Build konsumiert; die `prebuild`/`predev`-Hooks entfallen. `fetch-oparl` bleibt der Maintainer-Weg, den Roh-Snapshot lokal zu laden, um die Derivate zu regenerieren. Diese Entscheidung ändert nur die Bauzeit-Nutzung, nicht die externe Haltung der Rohdaten selbst. Siehe <<konzept-datenhaltung,Datenhaltung & Versionierung>>.
+====
+
 == Konsequenzen
 
 *Positiv*

--- a/docs/arc42/09-architekturentscheidungen/adr-0005-externe-oparl-rohdaten.adoc
+++ b/docs/arc42/09-architekturentscheidungen/adr-0005-externe-oparl-rohdaten.adoc
@@ -18,7 +18,7 @@ Der rohe OParl-Bestand (`data/oparl-magdeburg/`) umfasst rund 122 MB in wenigen 
 Der rohe OParl-Bestand wird *nicht mehr im Repository* gehalten (`data/oparl-magdeburg/` ist `gitignore`-t), sondern extern in der bestehenden AWS-S3/CloudFront-Infrastruktur unter dem Präfix `oparl/`. Statt einer Versionshistorie wird genau ein „aktueller“ Snapshot vorgehalten: inhaltsadressierte, unveränderliche Blobs (`oparl/<datei>.<sha>.json.gz`) und eine kleine `manifest.json` mit den Hashes und einem `lastSync`-Zeitstempel.
 
 * *Veröffentlichen* ist ein optionaler, authentifizierter Abschlussschritt des Scrapers (`scrape-oparl --push`); ohne das Flag schreibt der Scraper nur lokal. Nur dieser Schritt benötigt AWS-Zugangsdaten und ist dem Maintainer vorbehalten.
-* *Laden* erfolgt öffentlich und ohne Zugangsdaten über `fetch-oparl`; das Skript vergleicht die Hashes des Manifests mit den lokalen Dateien und lädt nur Geändertes. Es läuft automatisch über die `prebuild`/`predev`-Hooks der Web-Anwendung, sodass CI, Netlify und lokale Entwicklung den Bestand ohne Zusatzschritte erhalten.
+* *Laden* erfolgt öffentlich und ohne Zugangsdaten über `fetch-oparl`; das Skript vergleicht die Hashes des Manifests mit den lokalen Dateien und lädt nur Geändertes. Es ist ein manueller, dem Maintainer vorbehaltener Schritt. Der Astro-Build selbst benötigt den Roh-Snapshot nicht; er konsumiert stattdessen die committeten Derivate (`paper-index.json`, `voting-paper-map.json`, siehe Ergänzung unten). `fetch-oparl` lädt den Snapshot nur, wenn der Maintainer die Derivate neu erzeugen will.
 
 Diese Entscheidung betrifft ausschließlich die reproduzierbaren _Rohdaten_. Der verarbeitete Sitzungsbestand (Abstimmungen, Reden, `registry.json`) bleibt weiterhin versioniert im Repository (<<adr-0001,ADR-0001>>).
 
@@ -34,7 +34,7 @@ Diese Entscheidung betrifft ausschließlich die reproduzierbaren _Rohdaten_. Der
 * Repository und `.git`-Historie bleiben schlank; das Wachstum durch wiederholte Komplett-Überschreibungen entfällt.
 * Inhaltsadressierte, unveränderliche Blobs machen eine CloudFront-Invalidierung überflüssig; ein neuer Scrape erzeugt neue Blob-Namen und ein neues Manifest.
 * Offline-Entwicklung bleibt möglich: nach dem ersten Abruf liegen die Dateien lokal vor; ist das Manifest nicht erreichbar, aber alle Dateien vorhanden, wird mit dem lokalen Stand weitergearbeitet.
-* Die bestehenden Astro-Loader und das Repository-Muster der Deno-Skripte bleiben unverändert — sie lesen weiterhin lokale JSON-Dateien.
+* Der Astro-Build liest die rohen OParl-Daten nicht mehr direkt, sondern konsumiert die committeten Derivate (`paper-index.json`, `voting-paper-map.json`); das Repository-Muster der Deno-Skripte bleibt unverändert und liest den lokalen Roh-Snapshot weiterhin aus lokalen JSON-Dateien — nun ausschließlich zur Regenerierung der Derivate.
 
 *Negativ*
 

--- a/docs/guides/HOWTO.md
+++ b/docs/guides/HOWTO.md
@@ -326,11 +326,12 @@ deno run \
 
 ### Fetch OParl snapshot
 
-The processing scripts and the web build do not scrape OParl themselves — they read the local
-`data/oparl-magdeburg/` directory, which is populated by `fetch-oparl`. This step runs
-automatically before the web build and dev server (the `prebuild` / `predev` hooks in
-`astro/package.json` call `npm run fetch-oparl`), so CI, Netlify and local dev all obtain the data
-without extra steps. You can also run it on its own:
+The processing scripts read the local `data/oparl-magdeburg/` directory, which is populated by
+`fetch-oparl`. This is a **maintainer step**: it is necessary to (re)generate the committed OParl
+derivates via `generate-oparl-derivatives`. The Astro build itself consumes the committed derivates
+(`data/paper-index.json`, `data/{period}/voting-paper-map.json`).
+
+Run it when you need the raw snapshot:
 
 ```bash
 cd astro

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,12 @@
 # Netlify build configuration.
 #
-# `base = "astro"` makes Netlify install and build inside the astro/ workspace,
-# so `npm run build` runs its `prebuild` hook (npm run fetch-oparl) and pulls the
-# raw OParl snapshot from S3/CloudFront before the Astro build reads it.
+# `base = "astro"` makes Netlify install and build inside the astro/ workspace.
+# The Astro build reads only the committed OParl derivates (data/paper-index.json,
+# data/{period}/voting-paper-map.json), so it no longer fetches raw OParl data —
+# there is no prebuild fetch-oparl step anymore.
 # Paths below are relative to `base`, so `publish = "dist"` resolves to astro/dist.
 #
-# AWS_CLOUDFRONT_BASE_URL (and the other env vars in astro.config.mjs) must be set
-# in the Netlify site UI; reads are public, so no AWS credentials are needed.
+# The env vars in astro.config.mjs must be set in the Netlify site UI.
 
 [build]
   base = "astro"


### PR DESCRIPTION
…440)

Migrate the papers list to the committed paper-index.json derivate and remove the final raw-OParl content collection, so the Astro build no longer reads data/oparl-magdeburg/ at all (target of #437/#430).

- content.config.ts: replace oparlPapers with a paperIndex collection backed by the real Zod schema from oparl-derivatives.schema.ts.
- papers/index.astro + getRecentMainPapers consume paper-index.json; the 3-month window stays in the build. RecentPaper is now derived from PaperIndexEntry (paperType/name instead of type/title).
- Remove the prebuild/predev fetch-oparl hooks from package.json and the "Fetch OParl data" step from the CI workflow; update netlify.toml. fetch-oparl remains a maintainer-only tool to populate raw data for generate-oparl-derivatives.
- Update arc42 (Bausteinsicht, OParl-Ingestion runtime view, Datenhaltung, ADR-0005 amendment), HOWTO, CLAUDE.md + AGENTS.md Data Flow.

Parity verified once (throwaway): getRecentMainPapers over the derivate matches the old raw path exactly (230 entries). Build without the fetch-oparl hook is green; the /papers page renders 230 links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Data**
  * Builds now use committed OParl derivative data instead of fetching raw data automatically.
  * Development and production builds no longer trigger automatic data downloads.

* **Bug Fixes**
  * Updated recent-paper listings to use the new indexed data, including revised titles, types, references, and date handling.

* **Documentation**
  * Updated setup, architecture, and data-flow documentation to describe the revised data pipeline and maintainer workflow.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->