### PR TITLE
refactor(oparl-derivatives): use canonical Registry.id as period id

### DIFF
--- a/src/scripts/generate-oparl-derivatives/acceptance-tests/scenario.test.ts
+++ b/src/scripts/generate-oparl-derivatives/acceptance-tests/scenario.test.ts
@@ -4,7 +4,7 @@ import { OparlDerivativesGenerator } from '../oparl-derivatives-generator.ts';
 import { OparlObjectsStore } from '../../shared/oparl/oparl-objects-store.ts';
 import { RegistryStore } from '../registry-store.ts';
 import { DerivativesWriter } from '../derivatives-writer.ts';
-import { PeriodRegistry } from '../model.ts';
+import { Registry } from '@srw-astro/models/registry';
 import {
   OparlAgendaItem,
   OparlConsultation,
@@ -77,24 +77,23 @@ class MockOparlObjectsStore implements OparlObjectsStore {
   loadOrganizations = (): OparlOrganization[] => [];
 }
 
+const CANONICAL_PERIOD_ID = 'example-8';
+
 class MockRegistryStore implements RegistryStore {
-  loadRegistries = (): PeriodRegistry[] => [
+  loadRegistries = (): Registry[] => [
     {
-      periodId: 'example-8',
-      registry: {
-        id: 'example-8',
-        name: 'Example period',
-        lastUpdate: '2024-10-01',
-        sessions: [
-          session('2024-09-12'),
-          session('2024-08-15'),
-          // Registry session without a matching OParl meeting -> skipped.
-          session('2024-10-10'),
-        ],
-        factions: [],
-        parties: [],
-        persons: [],
-      },
+      id: CANONICAL_PERIOD_ID,
+      name: 'Example period',
+      lastUpdate: '2024-10-01',
+      sessions: [
+        session('2024-09-12'),
+        session('2024-08-15'),
+        // Registry session without a matching OParl meeting -> skipped.
+        session('2024-10-10'),
+      ],
+      factions: [],
+      parties: [],
+      persons: [],
     },
   ];
 }
@@ -122,9 +121,17 @@ describe('Generating OParl derivates', () => {
 
     runGeneration();
 
-    assertEquals(writer.votingPaperMaps['example-8'], {
+    assertEquals(writer.votingPaperMaps[CANONICAL_PERIOD_ID], {
       '2024-08-15': { '4.1': 100, '4.2': 200 },
     });
+  });
+
+  it('writes the voting-paper-map under the canonical registry id', () => {
+    givenStoresAreAvailable();
+
+    runGeneration();
+
+    assertEquals(Object.keys(writer.votingPaperMaps), [CANONICAL_PERIOD_ID]);
   });
 
   it('projects all dated main papers into a sorted paper index', () => {

--- a/src/scripts/generate-oparl-derivatives/model.ts
+++ b/src/scripts/generate-oparl-derivatives/model.ts
@@ -1,6 +1,0 @@
-import { Registry } from '@srw-astro/models/registry';
-
-export type PeriodRegistry = {
-  periodId: string; // the data/ subdirectory name, e.g. magdeburg-8
-  registry: Registry;
-};

--- a/src/scripts/generate-oparl-derivatives/oparl-derivatives-generator.ts
+++ b/src/scripts/generate-oparl-derivatives/oparl-derivatives-generator.ts
@@ -36,10 +36,10 @@ export class OparlDerivativesGenerator {
   public generate(): void {
     const councilMeetingsByDate = this.indexCouncilMeetingsByDate();
 
-    for (const { periodId, registry } of this.registryStore.loadRegistries()) {
-      console.log(`Generating voting-paper-map for period ${periodId}`);
+    for (const registry of this.registryStore.loadRegistries()) {
+      console.log(`Generating voting-paper-map for period ${registry.id}`);
       const votingPaperMap = this.buildVotingPaperMap(registry, councilMeetingsByDate);
-      this.writer.writeVotingPaperMap(periodId, votingPaperMap);
+      this.writer.writeVotingPaperMap(registry.id, votingPaperMap);
     }
 
     console.log('Generating global paper-index');

--- a/src/scripts/generate-oparl-derivatives/registry-store.ts
+++ b/src/scripts/generate-oparl-derivatives/registry-store.ts
@@ -1,17 +1,16 @@
 import * as path from '@std/path';
 import { Registry } from '@srw-astro/models/registry';
-import { PeriodRegistry } from './model.ts';
 
 export interface RegistryStore {
-  loadRegistries(): PeriodRegistry[];
+  loadRegistries(): Registry[];
 }
 
 export class RegistryFileStore implements RegistryStore {
   constructor(private readonly dataDir: string) {
   }
 
-  public loadRegistries(): PeriodRegistry[] {
-    const registries: PeriodRegistry[] = [];
+  public loadRegistries(): Registry[] {
+    const registries: Registry[] = [];
 
     for (const entry of Deno.readDirSync(this.dataDir)) {
       if (!entry.isDirectory) {
@@ -23,12 +22,11 @@ export class RegistryFileStore implements RegistryStore {
         continue;
       }
 
-      const registry = JSON.parse(Deno.readTextFileSync(registryPath)) as Registry;
-      registries.push({ periodId: entry.name, registry });
+      registries.push(JSON.parse(Deno.readTextFileSync(registryPath)) as Registry);
     }
 
-    // Sorted for a deterministic processing order across runs.
-    return registries.toSorted((a, b) => a.periodId.localeCompare(b.periodId));
+    // Sorted by the canonical registry id for a deterministic processing order across runs.
+    return registries.toSorted((a, b) => a.id.localeCompare(b.id));
   }
 }
 


### PR DESCRIPTION
Drop the PeriodRegistry wrapper that tracked the data/ subdirectory name alongside the registry. Loading and generation now use Registry.id as the canonical period identity, so directory name and registry id can no longer silently diverge. Deterministic ordering and per-registry voting-paper-map generation are preserved; a test asserts the map is written under the canonical registry id.

Closes #446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry processing by consistently using each registry’s canonical identifier.
  * Ensured generated voting-paper maps are written under the correct registry period.
  * Made registry loading order deterministic for more reliable derivative generation.
  * Updated validation coverage to confirm registry identifiers and generated outputs remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->