### PR TITLE
refactor(voting-breakdown): extract faction/person breakdown into shared module

### DIFF
--- a/astro/src/models/voting-breakdown.test.ts
+++ b/astro/src/models/voting-breakdown.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from 'vitest';
+import { getVotesByFactions, votingAccepted } from './voting-breakdown.ts';
+import type { Registry } from './registry.ts';
+import type { SessionScanItem } from './session-scan.ts';
+
+function createRegistry(): Registry {
+  return {
+    id: 'magdeburg-8',
+    name: 'Stadtrat Magdeburg 8',
+    lastUpdate: '2024-07-08',
+    sessions: [],
+    parties: [],
+    factions: [
+      { id: 'small', name: 'Small Faction', seats: 2 },
+      { id: 'large', name: 'Large Faction', seats: 10 },
+      { id: 'empty', name: 'Empty Faction', seats: 5 },
+    ],
+    persons: [
+      {
+        id: 'p1',
+        name: 'Abstainer',
+        factionId: 'large',
+        partyId: 'x',
+        start: null,
+        end: null,
+      },
+      {
+        id: 'p2',
+        name: 'Opposer',
+        factionId: 'large',
+        partyId: 'x',
+        start: null,
+        end: null,
+      },
+      {
+        id: 'p3',
+        name: 'Supporter',
+        factionId: 'large',
+        partyId: 'x',
+        start: null,
+        end: null,
+      },
+      {
+        id: 'p4',
+        name: 'Absentee',
+        factionId: 'large',
+        partyId: 'x',
+        start: null,
+        end: null,
+      },
+      {
+        id: 'p5',
+        name: 'Lone Voter',
+        factionId: 'small',
+        partyId: 'y',
+        start: null,
+        end: null,
+      },
+    ],
+  };
+}
+
+function createVoting(
+  votes: { name: string; vote: string }[],
+): SessionScanItem {
+  return {
+    votingFilename: '2024-07-08-001.png',
+    videoTimestamp: '00:10:00',
+    votingSubject: {
+      agendaItem: '12.6',
+      motionId: 'A123',
+      title: 'Ein Antrag',
+      type: 'Antrag',
+      authors: [],
+    },
+    votes,
+  };
+}
+
+describe('getVotesByFactions', () => {
+  test('orders factions by seats descending', () => {
+    const votesByFactions = getVotesByFactions(createRegistry(), []);
+
+    expect(votesByFactions.map((f) => f.factionId)).toEqual([
+      'large',
+      'empty',
+      'small',
+    ]);
+  });
+
+  test('assigns orderIndex following the seat order', () => {
+    const votesByFactions = getVotesByFactions(createRegistry(), []);
+
+    expect(votesByFactions.map((f) => f.orderIndex)).toEqual([0, 1, 2]);
+  });
+
+  test('keeps factions without votes with an empty vote list', () => {
+    const votesByFactions = getVotesByFactions(createRegistry(), [
+      { name: 'Lone Voter', vote: 'J' },
+    ]);
+
+    const emptyFaction = votesByFactions.find((f) => f.factionId === 'empty');
+    expect(emptyFaction?.votes).toEqual([]);
+  });
+
+  test('orders votes within a faction as yes, no, abstention, then anything else', () => {
+    const votesByFactions = getVotesByFactions(createRegistry(), [
+      { name: 'Absentee', vote: 'O' },
+      { name: 'Abstainer', vote: 'E' },
+      { name: 'Opposer', vote: 'N' },
+      { name: 'Supporter', vote: 'J' },
+    ]);
+
+    const largeFaction = votesByFactions.find((f) => f.factionId === 'large');
+    expect(largeFaction?.votes).toEqual([
+      { personName: 'Supporter', vote: 'J' },
+      { personName: 'Opposer', vote: 'N' },
+      { personName: 'Abstainer', vote: 'E' },
+      { personName: 'Absentee', vote: 'O' },
+    ]);
+  });
+
+  test('groups each vote under the faction of the voting person', () => {
+    const votesByFactions = getVotesByFactions(createRegistry(), [
+      { name: 'Supporter', vote: 'J' },
+      { name: 'Lone Voter', vote: 'N' },
+    ]);
+
+    expect(votesByFactions.find((f) => f.factionId === 'large')?.votes).toEqual(
+      [{ personName: 'Supporter', vote: 'J' }],
+    );
+    expect(votesByFactions.find((f) => f.factionId === 'small')?.votes).toEqual(
+      [{ personName: 'Lone Voter', vote: 'N' }],
+    );
+  });
+
+  test('exposes the faction name alongside the id', () => {
+    const votesByFactions = getVotesByFactions(createRegistry(), []);
+
+    expect(votesByFactions[0]).toMatchObject({
+      factionId: 'large',
+      factionName: 'Large Faction',
+    });
+  });
+
+  test('sorts unrecognized votes last, even when they collide with object property names', () => {
+    const votesByFactions = getVotesByFactions(createRegistry(), [
+      { name: 'Abstainer', vote: 'toString' },
+      { name: 'Supporter', vote: 'J' },
+    ]);
+
+    const largeFaction = votesByFactions.find((f) => f.factionId === 'large');
+    expect(largeFaction?.votes).toEqual([
+      { personName: 'Supporter', vote: 'J' },
+      { personName: 'Abstainer', vote: 'toString' },
+    ]);
+  });
+
+  test('fails when a vote references an unknown person', () => {
+    expect(() =>
+      getVotesByFactions(createRegistry(), [{ name: 'Ghost', vote: 'J' }]),
+    ).toThrow('Person Ghost not found');
+  });
+});
+
+describe('votingAccepted', () => {
+  test('accepts a voting with more yes than no votes', () => {
+    const voting = createVoting([
+      { name: 'Supporter', vote: 'J' },
+      { name: 'Opposer', vote: 'N' },
+      { name: 'Lone Voter', vote: 'J' },
+    ]);
+
+    expect(votingAccepted(voting)).toBe(true);
+  });
+
+  test('rejects a voting with a tie', () => {
+    const voting = createVoting([
+      { name: 'Supporter', vote: 'J' },
+      { name: 'Opposer', vote: 'N' },
+    ]);
+
+    expect(votingAccepted(voting)).toBe(false);
+  });
+
+  test('rejects a voting with more no than yes votes', () => {
+    const voting = createVoting([
+      { name: 'Opposer', vote: 'N' },
+      { name: 'Lone Voter', vote: 'N' },
+      { name: 'Supporter', vote: 'J' },
+    ]);
+
+    expect(votingAccepted(voting)).toBe(false);
+  });
+
+  test('ignores abstentions and non-votes when comparing', () => {
+    const voting = createVoting([
+      { name: 'Supporter', vote: 'J' },
+      { name: 'Abstainer', vote: 'E' },
+      { name: 'Absentee', vote: 'O' },
+    ]);
+
+    expect(votingAccepted(voting)).toBe(true);
+  });
+});

--- a/astro/src/models/voting-breakdown.ts
+++ b/astro/src/models/voting-breakdown.ts
@@ -16,10 +16,11 @@ const votePresentationOrder = new Map<string, number>([
   [VoteResult.DID_NOT_VOTE, 4],
 ]);
 
-const unrecognizedVotePresentationOrder = 4;
-
 function getVotePresentationOrder(vote: string): number {
-  return votePresentationOrder.get(vote) ?? unrecognizedVotePresentationOrder;
+  return (
+    votePresentationOrder.get(vote) ??
+    votePresentationOrder.get(VoteResult.DID_NOT_VOTE)!
+  );
 }
 
 function countVotes(votes: SessionScanVote[], voteResult: VoteResult): number {
@@ -30,10 +31,12 @@ export function getVotesByFactions(
   parliamentPeriod: Registry,
   votes: SessionScanVote[],
 ): VotesByFaction[] {
+  const personsByName = new Map(
+    parliamentPeriod.persons.map((person) => [person.name, person]),
+  );
+
   const votesWithFactionId = votes.map((vote) => {
-    const person = parliamentPeriod.persons.find(
-      (person) => person.name === vote.name,
-    );
+    const person = personsByName.get(vote.name);
     if (!person) {
       throw new Error(`Person ${vote.name} not found`);
     }

--- a/astro/src/models/voting-breakdown.ts
+++ b/astro/src/models/voting-breakdown.ts
@@ -1,0 +1,70 @@
+import type { Registry } from './registry.ts';
+import type { SessionScanItem, SessionScanVote } from './session-scan.ts';
+import { VoteResult } from './Session.ts';
+
+export type VotesByFaction = {
+  factionId: string;
+  factionName: string;
+  orderIndex: number;
+  votes: { personName: string; vote: string }[];
+};
+
+const votePresentationOrder = new Map<string, number>([
+  [VoteResult.VOTE_FOR, 1],
+  [VoteResult.VOTE_AGAINST, 2],
+  [VoteResult.VOTE_ABSTENTION, 3],
+  [VoteResult.DID_NOT_VOTE, 4],
+]);
+
+const unrecognizedVotePresentationOrder = 4;
+
+function getVotePresentationOrder(vote: string): number {
+  return votePresentationOrder.get(vote) ?? unrecognizedVotePresentationOrder;
+}
+
+function countVotes(votes: SessionScanVote[], voteResult: VoteResult): number {
+  return votes.filter((vote) => vote.vote === voteResult).length;
+}
+
+export function getVotesByFactions(
+  parliamentPeriod: Registry,
+  votes: SessionScanVote[],
+): VotesByFaction[] {
+  const votesWithFactionId = votes.map((vote) => {
+    const person = parliamentPeriod.persons.find(
+      (person) => person.name === vote.name,
+    );
+    if (!person) {
+      throw new Error(`Person ${vote.name} not found`);
+    }
+    return {
+      personName: person.name,
+      factionId: person.factionId,
+      vote: vote.vote,
+    };
+  });
+
+  return parliamentPeriod.factions
+    .toSorted((a, b) => b.seats - a.seats)
+    .map((faction, orderIndex) => ({
+      factionId: faction.id,
+      factionName: faction.name,
+      orderIndex,
+      votes: votesWithFactionId
+        .filter((vote) => vote.factionId === faction.id)
+        .toSorted(
+          (a, b) =>
+            getVotePresentationOrder(a.vote) - getVotePresentationOrder(b.vote),
+        )
+        .map((vote) => ({
+          personName: vote.personName,
+          vote: vote.vote,
+        })),
+    }));
+}
+
+export function votingAccepted(voting: SessionScanItem): boolean {
+  const votedFor = countVotes(voting.votes, VoteResult.VOTE_FOR);
+  const votedAgainst = countVotes(voting.votes, VoteResult.VOTE_AGAINST);
+  return votedFor > votedAgainst;
+}

--- a/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/_model.ts
+++ b/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/_model.ts
@@ -1,9 +1,4 @@
-export type VotesByFaction = {
-  factionId: string;
-  factionName: string;
-  orderIndex: number;
-  votes: { personName: string; vote: string }[];
-};
+import type { VotesByFaction } from '@models/voting-breakdown.ts';
 
 export type VotingListItem = {
   id: number;

--- a/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/_votings.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/_votings.astro
@@ -1,9 +1,12 @@
 ---
-import { type SessionScan, type SessionScanItem } from '@models/session-scan';
-import { type VotesByFaction, type VotingListItem } from './_model';
+import { type SessionScan } from '@models/session-scan';
+import { type VotingListItem } from './_model';
 import { getVotingId } from '@utils/session-utils';
-import { type SessionScanVote } from '@models/session-scan';
 import { type Registry } from '@models/registry';
+import {
+  getVotesByFactions,
+  votingAccepted,
+} from '@models/voting-breakdown.ts';
 
 type Props = {
   parliamentPeriod: Registry;
@@ -23,60 +26,11 @@ const votings = sessionScan
         title: voting.votingSubject.title,
         type: voting.votingSubject.type || '',
         authors: voting.votingSubject.authors,
-        votesByFactions: getVotesByFactions(voting.votes),
+        votesByFactions: getVotesByFactions(parliamentPeriod, voting.votes),
         accepted: votingAccepted(voting),
       }) satisfies VotingListItem,
   )
   .toSorted((a, b) => a.id - b.id);
-
-function getVotesByFactions(votes: SessionScanVote[]): VotesByFaction[] {
-  const votesWithFactionId = votes.map((vote) => {
-    const person = parliamentPeriod.persons.find((p) => p.name === vote.name);
-    if (!person) {
-      throw new Error(`Person ${vote.name} not found`);
-    }
-    return {
-      personName: person.name,
-      factionId: person.factionId,
-      vote: vote.vote,
-    };
-  });
-
-  return parliamentPeriod.factions
-    .toSorted((a, b) => b.seats - a.seats)
-    .map((faction, orderIndex) => {
-      const votes = votesWithFactionId
-        .filter((v) => v.factionId === faction.id)
-        .map((vote) => ({
-          ...vote,
-          orderIndex:
-            vote.vote === 'J'
-              ? 1
-              : vote.vote === 'N'
-                ? 2
-                : vote.vote === 'E'
-                  ? 3
-                  : 4,
-        }))
-        .toSorted((a, b) => a.orderIndex - b.orderIndex)
-        .map((vote) => ({
-          personName: vote.personName,
-          vote: vote.vote,
-        }));
-      return {
-        factionId: faction.id,
-        factionName: faction.name,
-        orderIndex,
-        votes,
-      };
-    });
-}
-
-function votingAccepted(voting: SessionScanItem) {
-  const votedFor = voting.votes.filter((vote) => vote.vote === 'J').length;
-  const votedAgainst = voting.votes.filter((vote) => vote.vote === 'N').length;
-  return votedFor > votedAgainst;
-}
 ---
 
 {

--- a/src/deps/astro/deno.json
+++ b/src/deps/astro/deno.json
@@ -8,6 +8,7 @@
     "./session-input": "./session-input.ts",
     "./session-scan": "./session-scan.ts",
     "./session-speech": "./session-speech.ts",
-    "./session": "./session.ts"
+    "./session": "./session.ts",
+    "./voting-breakdown": "./voting-breakdown.ts"
   }
 }

--- a/src/deps/astro/voting-breakdown.ts
+++ b/src/deps/astro/voting-breakdown.ts
@@ -1,0 +1,1 @@
+export * from '../../../astro/src/models/voting-breakdown.ts';


### PR DESCRIPTION
## Why

Prefactor for the »Abstimmungen« tab on the paper detail page (epic #458, spec `docs/wayfinder/448-abstimmungen-tab-spec.md` §6.1/§10.1).

The faction/person breakdown of a voting lived inside the SSR Astro component `_votings.astro`, so nothing else could reach it. The upcoming `generate-paper-votings` Deno generator (#455) has to produce **exactly** the same breakdown as the session page — this PR creates the seam it builds on, so both sides share one implementation instead of two that can drift.

Pure refactoring: no behaviour change, no new features.

## What changed

- **New** `astro/src/models/voting-breakdown.ts` — `getVotesByFactions` + `votingAccepted`, free of Astro/browser imports (depends only on `registry.ts`, `session-scan.ts`, `Session.ts`).
- **New** `astro/src/models/voting-breakdown.test.ts` — 12 unit tests: factions by seats desc, votes ordered J→N→E→else, hard failure on unknown person name, factions without votes kept.
- **New** `src/deps/astro/voting-breakdown.ts` + `deno.json` export — makes the module importable from Deno via `@srw-astro/models/voting-breakdown`.
- `_votings.astro` — 60 lines lighter, now calls the shared function.
- `_model.ts` — `VotesByFaction` now sourced from the shared module.

## Notes for the reviewer

**Rendering is provably unchanged.** Rather than assert it, I built the whole site from `c2e491d3` and from this branch and diffed the output: **0 of 4034 pages differ**, byte-for-byte.

**One bug caught in review, worth a look.** The first draft replaced the original `===` chain with a `Record<string, number>` lookup. That resolves prototype-chain keys — a vote value of `toString` would return an inherited *function*, `??` would never fire, and the comparator would yield `NaN`, silently reordering a faction's votes. Not reachable with real scan data (only `J`/`N`/`E`/`O` occur), but this module is exactly the seam #455 must match, so it's now a `Map` with an explicit `DID_NOT_VOTE` entry, pinned by a test that fails against the old lookup.

**Deliberately left out of scope:** `voting/[votingId]/index.astro:83` still computes `votedFor > votedAgainst` inline — a third copy of the accepted rule. It also needs those counts for display, so folding it in belongs in its own change.

**Checks:** `deno fmt`/`lint`/`test`/`check src/` and `npm run format:check`/`npm test` (50 passing)/`astro check` (0 errors, 0 warnings, 0 hints) all green.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added voting breakdowns grouped by faction, ordered by seat count and sorted by vote outcome.
  * Display includes faction names, voter names, and standardized vote choices.
  * Added a consistent “accepted” determination based on for vs against votes.
* **Bug Fixes**
  * Improved handling of abstentions, non-votes, unknown vote values, and factions with no votes.
  * Clear error when a voter reference can’t be resolved.
* **Refactor**
  * Updated session voting pages to reuse the shared voting breakdown logic.
* **Tests**
  * Added comprehensive tests for faction grouping, ordering, and acceptance rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->