### PR TITLE
feat(paper-votings): generate per-paper voting assets

### DIFF
--- a/astro/src/models/voting-breakdown.test.ts
+++ b/astro/src/models/voting-breakdown.test.ts
@@ -189,9 +189,10 @@ describe('getVoteCounts', () => {
       { name: 'Opposer', vote: 'N' },
       { name: 'Abstainer', vote: 'E' },
       { name: 'Absentee', vote: 'O' },
+      { name: 'Unknown Voter', vote: '?' },
     ]);
 
-    expect(getVoteCounts(voting)).toEqual({ J: 2, N: 1, E: 1, O: 1 });
+    expect(getVoteCounts(voting)).toEqual({ J: 2, N: 1, E: 1, O: 2 });
   });
 
   test('counts a voting without votes as all zero', () => {

--- a/astro/src/models/voting-breakdown.test.ts
+++ b/astro/src/models/voting-breakdown.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import { getVotesByFactions, votingAccepted } from './voting-breakdown.ts';
+import {
+  getVoteCounts,
+  getVotesByFactions,
+  getVotingId,
+  votingAccepted,
+} from './voting-breakdown.ts';
 import type { Registry } from './registry.ts';
 import type { SessionScanItem } from './session-scan.ts';
 
@@ -160,6 +165,37 @@ describe('getVotesByFactions', () => {
     expect(() =>
       getVotesByFactions(createRegistry(), [{ name: 'Ghost', vote: 'J' }]),
     ).toThrow('Person Ghost not found');
+  });
+});
+
+describe('getVotingId', () => {
+  test('reads the voting id encoded in the scan filename', () => {
+    expect(getVotingId(createVoting([]))).toBe(1);
+  });
+
+  test('reads a multi-digit voting id', () => {
+    const voting = createVoting([]);
+    voting.votingFilename = '2024-07-08-014.png';
+
+    expect(getVotingId(voting)).toBe(14);
+  });
+});
+
+describe('getVoteCounts', () => {
+  test('counts each vote result, treating anything unrecognized as not voted', () => {
+    const voting = createVoting([
+      { name: 'Supporter', vote: 'J' },
+      { name: 'Lone Voter', vote: 'J' },
+      { name: 'Opposer', vote: 'N' },
+      { name: 'Abstainer', vote: 'E' },
+      { name: 'Absentee', vote: 'O' },
+    ]);
+
+    expect(getVoteCounts(voting)).toEqual({ J: 2, N: 1, E: 1, O: 1 });
+  });
+
+  test('counts a voting without votes as all zero', () => {
+    expect(getVoteCounts(createVoting([]))).toEqual({ J: 0, N: 0, E: 0, O: 0 });
   });
 });
 

--- a/astro/src/models/voting-breakdown.ts
+++ b/astro/src/models/voting-breakdown.ts
@@ -9,6 +9,14 @@ export type VotesByFaction = {
   votes: { personName: string; vote: string }[];
 };
 
+// Keyed by the vote codes the scans carry (VoteResult), which the web assets expose as-is.
+export type VoteCounts = {
+  [VoteResult.VOTE_FOR]: number;
+  [VoteResult.VOTE_AGAINST]: number;
+  [VoteResult.VOTE_ABSTENTION]: number;
+  [VoteResult.DID_NOT_VOTE]: number;
+};
+
 const votePresentationOrder = new Map<string, number>([
   [VoteResult.VOTE_FOR, 1],
   [VoteResult.VOTE_AGAINST, 2],
@@ -23,8 +31,41 @@ function getVotePresentationOrder(vote: string): number {
   );
 }
 
-function countVotes(votes: SessionScanVote[], voteResult: VoteResult): number {
-  return votes.filter((vote) => vote.vote === voteResult).length;
+// The scan filename carries the voting id, e.g. 2024-07-08-014.png -> 14.
+const votingIdRange = { start: 11, end: 14 };
+
+export function getVotingId(voting: SessionScanItem): number {
+  return +voting.votingFilename.substring(
+    votingIdRange.start,
+    votingIdRange.end,
+  );
+}
+
+export function getVoteCounts(voting: SessionScanItem): VoteCounts {
+  const counts: VoteCounts = {
+    [VoteResult.VOTE_FOR]: 0,
+    [VoteResult.VOTE_AGAINST]: 0,
+    [VoteResult.VOTE_ABSTENTION]: 0,
+    [VoteResult.DID_NOT_VOTE]: 0,
+  };
+
+  for (const vote of voting.votes) {
+    const countedVote = isCountedVoteResult(vote.vote)
+      ? vote.vote
+      : VoteResult.DID_NOT_VOTE;
+    counts[countedVote]++;
+  }
+
+  return counts;
+}
+
+function isCountedVoteResult(vote: string): vote is keyof VoteCounts {
+  return (
+    vote === VoteResult.VOTE_FOR ||
+    vote === VoteResult.VOTE_AGAINST ||
+    vote === VoteResult.VOTE_ABSTENTION ||
+    vote === VoteResult.DID_NOT_VOTE
+  );
 }
 
 export function getVotesByFactions(
@@ -67,7 +108,6 @@ export function getVotesByFactions(
 }
 
 export function votingAccepted(voting: SessionScanItem): boolean {
-  const votedFor = countVotes(voting.votes, VoteResult.VOTE_FOR);
-  const votedAgainst = countVotes(voting.votes, VoteResult.VOTE_AGAINST);
-  return votedFor > votedAgainst;
+  const counts = getVoteCounts(voting);
+  return counts[VoteResult.VOTE_FOR] > counts[VoteResult.VOTE_AGAINST];
 }

--- a/astro/src/pages/api/v1/parliament-periods/[parliamentPeriodId]/votings/[sessionId].json.ts
+++ b/astro/src/pages/api/v1/parliament-periods/[parliamentPeriodId]/votings/[sessionId].json.ts
@@ -1,11 +1,9 @@
 import { getStaticPaths as getStaticParliamentPeriodPaths } from '../../[parliamentPeriodId].json.ts';
 import { generateMeta } from '../../../_helpers.ts';
 import { getEntry } from 'astro:content';
-import {
-  getVideoTimestampAsSeconds,
-  getVotingId,
-} from '@utils/session-utils.ts';
+import { getVideoTimestampAsSeconds } from '@utils/session-utils.ts';
 import type { Registry, RegistrySession } from '@models/registry.ts';
+import { getVotingId } from '@models/voting-breakdown.ts';
 
 export const getStaticPaths = async () => {
   const paths = await getStaticParliamentPeriodPaths();

--- a/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/_votings.astro
+++ b/astro/src/pages/pp/[parliamentPeriodId]/session/[sessionId]/_votings.astro
@@ -1,10 +1,10 @@
 ---
 import { type SessionScan } from '@models/session-scan';
 import { type VotingListItem } from './_model';
-import { getVotingId } from '@utils/session-utils';
 import { type Registry } from '@models/registry';
 import {
   getVotesByFactions,
+  getVotingId,
   votingAccepted,
 } from '@models/voting-breakdown.ts';
 

--- a/astro/src/utils/session-utils.ts
+++ b/astro/src/utils/session-utils.ts
@@ -72,8 +72,6 @@ export function getFactionOfPerson(
   );
 }
 
-export { getVotingId } from '@models/voting-breakdown.ts';
-
 export function getVideoTimestampAsSeconds(voting: SessionScanItem): number {
   const timeParts = voting.videoTimestamp.split(':');
   switch (timeParts.length) {

--- a/astro/src/utils/session-utils.ts
+++ b/astro/src/utils/session-utils.ts
@@ -72,9 +72,7 @@ export function getFactionOfPerson(
   );
 }
 
-export function getVotingId(voting: SessionScanItem) {
-  return +voting.votingFilename.substring(11, 14);
-}
+export { getVotingId } from '@models/voting-breakdown.ts';
 
 export function getVideoTimestampAsSeconds(voting: SessionScanItem): number {
   const timeParts = voting.videoTimestamp.split(':');

--- a/docker/generate-paper-votings.Dockerfile
+++ b/docker/generate-paper-votings.Dockerfile
@@ -1,0 +1,20 @@
+FROM denoland/deno:2.3.3
+
+WORKDIR /app
+
+COPY deno.json /app
+COPY deno.lock /app
+COPY src /app/src
+COPY astro/src/models /app/astro/src/models
+
+RUN deno install --entrypoint src/scripts/generate-paper-votings/index.ts --unstable-sloppy-imports
+
+
+USER deno
+
+CMD ["run", \
+        "-R=/app/data", \
+        "-W=/app/generated", \
+        "src/scripts/generate-paper-votings/index.ts", \
+        "-d=./data", \
+        "-o=./generated"]

--- a/docs/guides/HOWTO.md
+++ b/docs/guides/HOWTO.md
@@ -10,7 +10,8 @@ Run the processing pipeline in this order. The script sections below document in
    2. `scan-voting-images` - extract voting results from session screenshots.
    3. `speech-to-text` - generate speech transcriptions.
 4. `generate-image-assets` - create voting visualization image assets from processed session data.
-5. `index-search` - rebuild the Typesense search index after all paper, speech, and asset data is available.
+5. `generate-paper-votings` - reverse the voting-paper-map against the session scans into the per-paper voting assets. Needs both the OParl derivates (step 2) and the scanned votings (step 3.2).
+6. `index-search` - rebuild the Typesense search index after all paper, speech, and asset data is available.
 
 
 ### Parse Speakers
@@ -195,6 +196,42 @@ docker run \
   -v $(pwd)/output/ratsinfosystem:/app/oparl:ro \
   -v $(pwd)/data:/app/data \
   srw-generate-oparl-derivatives
+```
+
+
+### Generate paper votings
+This tool builds the web assets behind the »Abstimmungen« tab on the paper detail page. The link from a voting to a paper only exists forwards (`{period}/voting-paper-map.json`: session date → agenda item → paper id), so this tool reverses it at build time and resolves each vote to its person and faction against the period's `registry.json` — the same breakdown the session detail page renders.
+
+It scans `<data-dir>` for `{period-id}/registry.json` and intersects each period's `voting-paper-map.json` with the session scans: only agenda items that were **actually scanned** produce a voting, so papers that were never voted on do not appear in the output at all (which is what disables the tab). A paper voted on in several parliament periods collects the votings of all of them, each joined against its own registry.
+
+Output is batched by paper id (`paper-votings-{batch}.json`, `batch = paperId / 100`), stably sorted (session date descending, then voting id ascending), so a repeated run produces no diff. The files belong next to the other web assets on S3/CloudFront under `web-assets/paper-votings/`.
+
+Run this **after** the OParl derivates (`voting-paper-map.json`) and the video processing (`session-scan-*.json`) exist.
+
+#### Using the deno script
+```shell
+deno run \
+  -R=data \
+  -W=output/paper-votings \
+  src/scripts/generate-paper-votings/index.ts \
+  -d=data/ \
+  -o=output/paper-votings/
+```
+
+`-d`/`--data-dir` defaults to `data/`, so it can be omitted when run from the repository root.
+
+#### Build the docker image
+```bash
+docker build -t srw-generate-paper-votings -f docker/generate-paper-votings.Dockerfile .
+```
+
+#### Run the docker container
+```shell
+docker run \
+  --rm \
+  -v $(pwd)/data:/app/data:ro \
+  -v $(pwd)/output/paper-votings:/app/generated \
+  srw-generate-paper-votings
 ```
 
 

--- a/src/scripts/generate-paper-votings/acceptance-tests/scenario.test.ts
+++ b/src/scripts/generate-paper-votings/acceptance-tests/scenario.test.ts
@@ -134,15 +134,23 @@ describe('Generating paper votings', () => {
               vote('Opposer', 'N'),
               vote('Abstainer', 'E'),
               vote('Absentee', 'O'),
+              vote('Unknown Voter', '?'),
             ]),
           ],
         },
+        persons: [
+          person('Supporter', 'faction-1'),
+          person('Opposer', 'faction-1'),
+          person('Abstainer', 'faction-1'),
+          person('Absentee', 'faction-1'),
+          person('Unknown Voter', 'faction-1'),
+        ],
       }),
     ]);
 
     runGeneration();
 
-    assertEquals(votingsOf(111)[0].counts, { J: 1, N: 1, E: 1, O: 1 });
+    assertEquals(votingsOf(111)[0].counts, { J: 1, N: 1, E: 1, O: 2 });
   });
 
   it('accepts a voting with more yes than no votes', () => {

--- a/src/scripts/generate-paper-votings/acceptance-tests/scenario.test.ts
+++ b/src/scripts/generate-paper-votings/acceptance-tests/scenario.test.ts
@@ -1,0 +1,316 @@
+import { describe, it } from '@std/testing/bdd';
+import { assertEquals, assertThrows } from '@std/assert';
+import { PaperVotingsGenerator } from '../paper-votings-generator.ts';
+import { PeriodData, PeriodDataStore } from '../period-data-store.ts';
+import { PaperVotingsWriter } from '../paper-votings-writer.ts';
+import { PaperVotingsAssetDto, PaperVotingsDto } from '../model.ts';
+import { Registry, RegistryFaction, RegistryPerson } from '@srw-astro/models/registry';
+import { SessionScan, SessionScanItem, SessionScanVote } from '@srw-astro/models/session-scan';
+
+const PERIOD_7 = 'example-7';
+const PERIOD_8 = 'example-8';
+
+// Mirrors the live 239123 case: the same paper voted on in both parliament periods.
+const CROSS_PERIOD_PAPER = 239123;
+// Mirrors the live 243686 case: two scans for one agenda item in one session.
+const MULTI_SCAN_PAPER = 243686;
+const LOW_ID_PAPER = 42;
+
+class MockPeriodDataStore implements PeriodDataStore {
+  constructor(private readonly periods: PeriodData[]) {
+  }
+
+  loadPeriods = (): PeriodData[] => this.periods;
+}
+
+class MockPaperVotingsWriter implements PaperVotingsWriter {
+  assets: PaperVotingsAssetDto[] = [];
+
+  writePaperVotings(assets: PaperVotingsAssetDto[]): void {
+    this.assets = assets;
+  }
+}
+
+describe('Generating paper votings', () => {
+  let writer: MockPaperVotingsWriter;
+  let generator: PaperVotingsGenerator;
+
+  it('omits agenda items that are mapped to a paper but were never scanned', () => {
+    givenPeriods([
+      period(PERIOD_8, {
+        votingPaperMap: { '2024-07-08': { '1.1': 111 } },
+        sessionScansByDate: { '2024-07-08': [] },
+      }),
+    ]);
+
+    runGeneration();
+
+    assertEquals(writer.assets, []);
+  });
+
+  it('omits scanned agenda items that are not mapped to any paper', () => {
+    givenPeriods([
+      period(PERIOD_8, {
+        votingPaperMap: {},
+        sessionScansByDate: { '2024-07-08': [scan('2024-07-08-001.png', '1.1')] },
+      }),
+    ]);
+
+    runGeneration();
+
+    assertEquals(writer.assets, []);
+  });
+
+  it('keeps every scan of the same agenda item as its own voting', () => {
+    givenPeriods([
+      period(PERIOD_8, {
+        votingPaperMap: { '2024-07-08': { '12.6': MULTI_SCAN_PAPER } },
+        sessionScansByDate: {
+          '2024-07-08': [
+            scan('2024-07-08-012.png', '12.6'),
+            scan('2024-07-08-014.png', '12.6'),
+          ],
+        },
+      }),
+    ]);
+
+    runGeneration();
+
+    assertEquals(votingsOf(MULTI_SCAN_PAPER).map((voting) => voting.votingId), [12, 14]);
+  });
+
+  it('merges votings of one paper across parliament periods, each against its own registry', () => {
+    givenPeriods([
+      period(PERIOD_7, {
+        votingPaperMap: { '2022-09-01': { '6.29': CROSS_PERIOD_PAPER } },
+        sessionScansByDate: {
+          '2022-09-01': [scan('2022-09-01-003.png', '6.29', [vote('Old Councillor', 'J')])],
+        },
+        factions: [faction('old-faction', 'Old Faction', 5)],
+        persons: [person('Old Councillor', 'old-faction')],
+      }),
+      period(PERIOD_8, {
+        votingPaperMap: { '2024-10-17': { '7.1': CROSS_PERIOD_PAPER } },
+        sessionScansByDate: {
+          '2024-10-17': [scan('2024-10-17-005.png', '7.1', [vote('New Councillor', 'J')])],
+        },
+        factions: [faction('new-faction', 'New Faction', 7)],
+        persons: [person('New Councillor', 'new-faction')],
+      }),
+    ]);
+
+    runGeneration();
+
+    assertEquals(
+      votingsOf(CROSS_PERIOD_PAPER).map((voting) => [voting.parliamentPeriodId, voting.sessionId]),
+      [[PERIOD_8, '2024-10-17'], [PERIOD_7, '2022-09-01']],
+    );
+    assertEquals(votingsOf(CROSS_PERIOD_PAPER)[0].votesByFactions, [
+      {
+        factionId: 'new-faction',
+        factionName: 'New Faction',
+        orderIndex: 0,
+        votes: [{ personName: 'New Councillor', vote: 'J' }],
+      },
+    ]);
+    assertEquals(votingsOf(CROSS_PERIOD_PAPER)[1].votesByFactions, [
+      {
+        factionId: 'old-faction',
+        factionName: 'Old Faction',
+        orderIndex: 0,
+        votes: [{ personName: 'Old Councillor', vote: 'J' }],
+      },
+    ]);
+  });
+
+  it('counts votes per result, treating anything that is not yes, no or abstention as absent', () => {
+    givenPeriods([
+      period(PERIOD_8, {
+        votingPaperMap: { '2024-07-08': { '1.1': 111 } },
+        sessionScansByDate: {
+          '2024-07-08': [
+            scan('2024-07-08-001.png', '1.1', [
+              vote('Supporter', 'J'),
+              vote('Opposer', 'N'),
+              vote('Abstainer', 'E'),
+              vote('Absentee', 'O'),
+            ]),
+          ],
+        },
+      }),
+    ]);
+
+    runGeneration();
+
+    assertEquals(votingsOf(111)[0].counts, { J: 1, N: 1, E: 1, O: 1 });
+  });
+
+  it('accepts a voting with more yes than no votes', () => {
+    givenPeriods([periodWithVotes([vote('Supporter', 'J'), vote('Opposer', 'N'), vote('Abstainer', 'J')])]);
+
+    runGeneration();
+
+    assertEquals(votingsOf(111)[0].accepted, true);
+  });
+
+  it('rejects a voting without a yes majority', () => {
+    givenPeriods([periodWithVotes([vote('Supporter', 'J'), vote('Opposer', 'N')])]);
+
+    runGeneration();
+
+    assertEquals(votingsOf(111)[0].accepted, false);
+  });
+
+  it('carries the scanned subject through to the asset', () => {
+    givenPeriods([
+      period(PERIOD_8, {
+        votingPaperMap: { '2024-07-08': { '12.6': MULTI_SCAN_PAPER } },
+        sessionScansByDate: { '2024-07-08': [scan('2024-07-08-012.png', '12.6')] },
+      }),
+    ]);
+
+    runGeneration();
+
+    const voting = votingsOf(MULTI_SCAN_PAPER)[0];
+    assertEquals(voting.agendaItem, '12.6');
+    assertEquals(voting.title, 'Subject 12.6');
+    assertEquals(voting.type, 'Antrag');
+    assertEquals(voting.date, '2024-07-08');
+  });
+
+  it('sorts votings by session date descending, then by voting id ascending', () => {
+    givenPeriods([
+      period(PERIOD_8, {
+        votingPaperMap: {
+          '2024-07-08': { '1.1': 111 },
+          '2024-10-17': { '2.1': 111 },
+        },
+        sessionScansByDate: {
+          '2024-07-08': [scan('2024-07-08-014.png', '1.1'), scan('2024-07-08-002.png', '1.1')],
+          '2024-10-17': [scan('2024-10-17-009.png', '2.1')],
+        },
+      }),
+    ]);
+
+    runGeneration();
+
+    assertEquals(
+      votingsOf(111).map((voting) => [voting.date, voting.votingId]),
+      [['2024-10-17', 9], ['2024-07-08', 2], ['2024-07-08', 14]],
+    );
+  });
+
+  it('groups papers into batches of hundred, padded to four digits', () => {
+    givenPeriods([
+      period(PERIOD_8, {
+        votingPaperMap: { '2024-07-08': { '1.1': LOW_ID_PAPER, '2.2': CROSS_PERIOD_PAPER } },
+        sessionScansByDate: {
+          '2024-07-08': [scan('2024-07-08-001.png', '1.1'), scan('2024-07-08-002.png', '2.2')],
+        },
+      }),
+    ]);
+
+    runGeneration();
+
+    assertEquals(writer.assets.map((asset) => asset.batchNo), ['0000', '2391']);
+    assertEquals(writer.assets[0].paperVotings.map((entry) => entry.paperId), [LOW_ID_PAPER]);
+    assertEquals(writer.assets[1].paperVotings.map((entry) => entry.paperId), [CROSS_PERIOD_PAPER]);
+  });
+
+  it('fails when a vote references a person outside the period registry', () => {
+    givenPeriods([periodWithVotes([vote('Ghost', 'J')])]);
+
+    assertThrows(() => runGeneration(), Error, 'Person Ghost not found');
+  });
+
+  function givenPeriods(periods: PeriodData[]) {
+    writer = new MockPaperVotingsWriter();
+    generator = new PaperVotingsGenerator(new MockPeriodDataStore(periods), writer);
+  }
+
+  function runGeneration() {
+    generator.generatePaperVotings();
+  }
+
+  function votingsOf(paperId: number) {
+    const entries = writer.assets.flatMap((asset) => asset.paperVotings);
+    const entry = entries.find((candidate: PaperVotingsDto) => candidate.paperId === paperId);
+    if (!entry) {
+      throw new Error(`No paper votings generated for paper ${paperId}`);
+    }
+    return entry.votings;
+  }
+});
+
+function periodWithVotes(votes: SessionScanVote[]): PeriodData {
+  return period(PERIOD_8, {
+    votingPaperMap: { '2024-07-08': { '1.1': 111 } },
+    sessionScansByDate: { '2024-07-08': [scan('2024-07-08-001.png', '1.1', votes)] },
+  });
+}
+
+function period(
+  periodId: string,
+  options: {
+    votingPaperMap: PeriodData['votingPaperMap'];
+    sessionScansByDate: { [sessionDate: string]: SessionScan };
+    factions?: RegistryFaction[];
+    persons?: RegistryPerson[];
+  },
+): PeriodData {
+  const factions = options.factions ?? [faction('faction-1', 'Faction 1', 10)];
+  const persons = options.persons ?? [
+    person('Supporter', 'faction-1'),
+    person('Opposer', 'faction-1'),
+    person('Abstainer', 'faction-1'),
+    person('Absentee', 'faction-1'),
+  ];
+
+  return {
+    registry: {
+      id: periodId,
+      name: `Period ${periodId}`,
+      lastUpdate: '2024-10-01',
+      sessions: Object.keys(options.sessionScansByDate).map((date) => ({
+        id: date,
+        date,
+        title: `Session ${date}`,
+        youtubeUrl: '',
+        meetingMinutesUrl: null,
+        approved: true,
+      })),
+      factions,
+      parties: [],
+      persons,
+    } satisfies Registry,
+    votingPaperMap: options.votingPaperMap,
+    sessionScansByDate: options.sessionScansByDate,
+  };
+}
+
+function scan(votingFilename: string, agendaItem: string, votes: SessionScanVote[] = []): SessionScanItem {
+  return {
+    votingFilename,
+    videoTimestamp: '00:10:00',
+    votingSubject: {
+      agendaItem,
+      motionId: 'M1',
+      title: `Subject ${agendaItem}`,
+      type: 'Antrag',
+      authors: [],
+    },
+    votes,
+  };
+}
+
+function vote(name: string, voteResult: string): SessionScanVote {
+  return { name, vote: voteResult };
+}
+
+function faction(id: string, name: string, seats: number): RegistryFaction {
+  return { id, name, seats };
+}
+
+function person(name: string, factionId: string): RegistryPerson {
+  return { id: name.toLowerCase().replace(' ', '-'), name, factionId, partyId: 'party-1', start: null, end: null };
+}

--- a/src/scripts/generate-paper-votings/cli.ts
+++ b/src/scripts/generate-paper-votings/cli.ts
@@ -1,0 +1,54 @@
+import { parseArgs as stdCliParseArgs } from '@std/cli/parse-args';
+
+export type GeneratePaperVotingsArgs = {
+  help: boolean;
+  dataDir: string;
+  outputDir: string;
+};
+
+export function parseArgs(args: string[]): GeneratePaperVotingsArgs {
+  return stdCliParseArgs(args, {
+    boolean: ['help'],
+    string: ['data-dir', 'output-dir'],
+    alias: {
+      help: 'h',
+      'data-dir': ['d', 'dataDir'],
+      'output-dir': ['o', 'outputDir'],
+    },
+    default: {
+      'data-dir': 'data/',
+    },
+  }) as GeneratePaperVotingsArgs;
+}
+
+export function checkArgs(args: GeneratePaperVotingsArgs) {
+  const { dataDir, outputDir } = args;
+
+  if (!dataDir) {
+    console.error('Missing data directory. See --help for usage.');
+    Deno.exit(1);
+  }
+
+  if (!outputDir) {
+    console.error('Missing output directory. See --help for usage.');
+    Deno.exit(1);
+  }
+}
+
+export function printHelpText() {
+  console.log(`
+Usage: deno run index.ts [-d <data-dir>] -o <output-dir>
+
+Scans <data-dir> for {period-id}/registry.json and reverses every period's
+voting-paper-map.json against the scanned votings, so that each paper carries the
+votings it was decided in - including the faction/person breakdown. Papers without
+a scanned voting do not appear in the output.
+
+-h, --help                  Show this help message and exit.
+-d, --data-dir              The data directory containing the parliament period
+                            registries, voting-paper-maps and session scans.
+                            Default: data/
+-o, --output-dir            The output directory. Batched json files
+                            (paper-votings-{batch}.json) will be written here.
+  `);
+}

--- a/src/scripts/generate-paper-votings/index.ts
+++ b/src/scripts/generate-paper-votings/index.ts
@@ -1,0 +1,21 @@
+import { checkArgs, parseArgs, printHelpText } from './cli.ts';
+import { PeriodDataFileStore } from './period-data-store.ts';
+import { PaperVotingsGenerator } from './paper-votings-generator.ts';
+import { PaperVotingsFileWriter } from './paper-votings-writer.ts';
+
+const args = parseArgs(Deno.args);
+
+if (args.help) {
+  printHelpText();
+  Deno.exit(0);
+}
+
+checkArgs(args);
+
+const periodDataStore = new PeriodDataFileStore(args.dataDir);
+const paperVotingsWriter = new PaperVotingsFileWriter(args.outputDir);
+
+const generator = new PaperVotingsGenerator(periodDataStore, paperVotingsWriter);
+generator.generatePaperVotings();
+
+console.log('Done.');

--- a/src/scripts/generate-paper-votings/model.ts
+++ b/src/scripts/generate-paper-votings/model.ts
@@ -1,11 +1,4 @@
-import { VotesByFaction } from '@srw-astro/models/voting-breakdown';
-
-export type VoteCounts = {
-  J: number;
-  N: number;
-  E: number;
-  O: number;
-};
+import { VoteCounts, VotesByFaction } from '@srw-astro/models/voting-breakdown';
 
 export type PaperVotingItem = {
   parliamentPeriodId: string;

--- a/src/scripts/generate-paper-votings/model.ts
+++ b/src/scripts/generate-paper-votings/model.ts
@@ -1,0 +1,31 @@
+import { VotesByFaction } from '@srw-astro/models/voting-breakdown';
+
+export type VoteCounts = {
+  J: number;
+  N: number;
+  E: number;
+  O: number;
+};
+
+export type PaperVotingItem = {
+  parliamentPeriodId: string;
+  sessionId: string;
+  date: string;
+  votingId: number;
+  agendaItem: string;
+  title: string;
+  type: string;
+  accepted: boolean;
+  counts: VoteCounts;
+  votesByFactions: VotesByFaction[];
+};
+
+export type PaperVotingsDto = {
+  paperId: number;
+  votings: PaperVotingItem[];
+};
+
+export type PaperVotingsAssetDto = {
+  batchNo: string;
+  paperVotings: PaperVotingsDto[];
+};

--- a/src/scripts/generate-paper-votings/paper-votings-generator.ts
+++ b/src/scripts/generate-paper-votings/paper-votings-generator.ts
@@ -1,0 +1,117 @@
+import { getVotesByFactions, votingAccepted } from '@srw-astro/models/voting-breakdown';
+import { SessionScanItem } from '@srw-astro/models/session-scan';
+import { Registry } from '@srw-astro/models/registry';
+import { VoteResult } from '@srw-astro/models/session';
+import { PeriodData, PeriodDataStore } from './period-data-store.ts';
+import { PaperVotingsWriter } from './paper-votings-writer.ts';
+import { PaperVotingItem, PaperVotingsAssetDto, PaperVotingsDto, VoteCounts } from './model.ts';
+
+export class PaperVotingsGenerator {
+  constructor(
+    private readonly periodDataStore: PeriodDataStore,
+    private readonly writer: PaperVotingsWriter,
+  ) {
+  }
+
+  public generatePaperVotings(): void {
+    const votingsByPaperId = new Map<number, PaperVotingItem[]>();
+
+    for (const period of this.periodDataStore.loadPeriods()) {
+      console.log(`Collecting paper votings for period ${period.registry.id}`);
+      this.collectPeriodVotings(period, votingsByPaperId);
+    }
+
+    const paperVotings = this.sortPaperVotings(votingsByPaperId);
+    console.log(`Generated votings for ${paperVotings.length} papers`);
+    this.writer.writePaperVotings(this.batchPaperVotings(paperVotings));
+  }
+
+  private collectPeriodVotings(period: PeriodData, votingsByPaperId: Map<number, PaperVotingItem[]>): void {
+    for (const [sessionDate, paperIdByAgendaItem] of Object.entries(period.votingPaperMap)) {
+      const sessionScan = period.sessionScansByDate[sessionDate] ?? [];
+
+      for (const [agendaItem, paperId] of Object.entries(paperIdByAgendaItem)) {
+        const scansOfAgendaItem = sessionScan.filter((scan) => scan.votingSubject.agendaItem === agendaItem);
+
+        for (const scan of scansOfAgendaItem) {
+          const votings = votingsByPaperId.get(paperId) ?? [];
+          votings.push(this.toPaperVotingItem(scan, sessionDate, period.registry));
+          votingsByPaperId.set(paperId, votings);
+        }
+      }
+    }
+  }
+
+  private toPaperVotingItem(scan: SessionScanItem, sessionDate: string, registry: Registry): PaperVotingItem {
+    return {
+      parliamentPeriodId: registry.id,
+      sessionId: sessionDate,
+      date: sessionDate,
+      votingId: getVotingId(scan),
+      agendaItem: scan.votingSubject.agendaItem,
+      title: scan.votingSubject.title,
+      type: scan.votingSubject.type || '',
+      accepted: votingAccepted(scan),
+      counts: countVotes(scan),
+      votesByFactions: getVotesByFactions(registry, scan.votes),
+    };
+  }
+
+  private sortPaperVotings(votingsByPaperId: Map<number, PaperVotingItem[]>): PaperVotingsDto[] {
+    return [...votingsByPaperId.entries()]
+      .map<PaperVotingsDto>(([paperId, votings]) => ({
+        paperId,
+        votings: votings.toSorted((a, b) => {
+          const dateComparison = b.date.localeCompare(a.date);
+          return dateComparison !== 0 ? dateComparison : a.votingId - b.votingId;
+        }),
+      }))
+      .toSorted((a, b) => a.paperId - b.paperId);
+  }
+
+  private batchPaperVotings(paperVotings: PaperVotingsDto[]): PaperVotingsAssetDto[] {
+    const paperVotingsByBatchNo = new Map<string, PaperVotingsDto[]>();
+
+    for (const entry of paperVotings) {
+      const batchNo = getBatchNo(entry.paperId);
+      const batch = paperVotingsByBatchNo.get(batchNo) ?? [];
+      batch.push(entry);
+      paperVotingsByBatchNo.set(batchNo, batch);
+    }
+
+    return [...paperVotingsByBatchNo.entries()]
+      .map<PaperVotingsAssetDto>(([batchNo, entries]) => ({ batchNo, paperVotings: entries }))
+      .toSorted((a, b) => a.batchNo.localeCompare(b.batchNo));
+  }
+}
+
+// The scan filename encodes the voting id, mirroring getVotingId in the web app's session-utils.
+function getVotingId(scan: SessionScanItem): number {
+  return +scan.votingFilename.substring(11, 14);
+}
+
+function getBatchNo(paperId: number): string {
+  return `${Math.floor(paperId / 100)}`.padStart(4, '0');
+}
+
+function countVotes(scan: SessionScanItem): VoteCounts {
+  const counts: VoteCounts = { J: 0, N: 0, E: 0, O: 0 };
+
+  for (const vote of scan.votes) {
+    switch (vote.vote) {
+      case VoteResult.VOTE_FOR:
+        counts.J++;
+        break;
+      case VoteResult.VOTE_AGAINST:
+        counts.N++;
+        break;
+      case VoteResult.VOTE_ABSTENTION:
+        counts.E++;
+        break;
+      default:
+        counts.O++;
+    }
+  }
+
+  return counts;
+}

--- a/src/scripts/generate-paper-votings/paper-votings-generator.ts
+++ b/src/scripts/generate-paper-votings/paper-votings-generator.ts
@@ -1,10 +1,9 @@
-import { getVotesByFactions, votingAccepted } from '@srw-astro/models/voting-breakdown';
+import { getVoteCounts, getVotesByFactions, getVotingId, votingAccepted } from '@srw-astro/models/voting-breakdown';
 import { SessionScanItem } from '@srw-astro/models/session-scan';
 import { Registry } from '@srw-astro/models/registry';
-import { VoteResult } from '@srw-astro/models/session';
 import { PeriodData, PeriodDataStore } from './period-data-store.ts';
 import { PaperVotingsWriter } from './paper-votings-writer.ts';
-import { PaperVotingItem, PaperVotingsAssetDto, PaperVotingsDto, VoteCounts } from './model.ts';
+import { PaperVotingItem, PaperVotingsAssetDto, PaperVotingsDto } from './model.ts';
 
 export class PaperVotingsGenerator {
   constructor(
@@ -52,7 +51,7 @@ export class PaperVotingsGenerator {
       title: scan.votingSubject.title,
       type: scan.votingSubject.type || '',
       accepted: votingAccepted(scan),
-      counts: countVotes(scan),
+      counts: getVoteCounts(scan),
       votesByFactions: getVotesByFactions(registry, scan.votes),
     };
   }
@@ -85,33 +84,6 @@ export class PaperVotingsGenerator {
   }
 }
 
-// The scan filename encodes the voting id, mirroring getVotingId in the web app's session-utils.
-function getVotingId(scan: SessionScanItem): number {
-  return +scan.votingFilename.substring(11, 14);
-}
-
 function getBatchNo(paperId: number): string {
   return `${Math.floor(paperId / 100)}`.padStart(4, '0');
-}
-
-function countVotes(scan: SessionScanItem): VoteCounts {
-  const counts: VoteCounts = { J: 0, N: 0, E: 0, O: 0 };
-
-  for (const vote of scan.votes) {
-    switch (vote.vote) {
-      case VoteResult.VOTE_FOR:
-        counts.J++;
-        break;
-      case VoteResult.VOTE_AGAINST:
-        counts.N++;
-        break;
-      case VoteResult.VOTE_ABSTENTION:
-        counts.E++;
-        break;
-      default:
-        counts.O++;
-    }
-  }
-
-  return counts;
 }

--- a/src/scripts/generate-paper-votings/paper-votings-writer.ts
+++ b/src/scripts/generate-paper-votings/paper-votings-writer.ts
@@ -12,9 +12,29 @@ export class PaperVotingsFileWriter implements PaperVotingsWriter {
   writePaperVotings(assets: PaperVotingsAssetDto[]): void {
     Deno.mkdirSync(this.paperVotingsDir, { recursive: true });
 
+    const generatedFilenames = this.writePaperVotingFiles(assets);
+    this.removeStalePaperVotingsFiles(generatedFilenames);
+  }
+
+  private writePaperVotingFiles(assets: PaperVotingsAssetDto[]): Set<string> {
+    const generatedFilenames = new Set<string>();
     for (const asset of assets) {
-      const filename = path.join(this.paperVotingsDir, `paper-votings-${asset.batchNo}.json`);
-      Deno.writeTextFileSync(filename, JSON.stringify(asset.paperVotings, null, 2));
+      const filename = `paper-votings-${asset.batchNo}.json`;
+      generatedFilenames.add(filename);
+      const filePath = path.join(this.paperVotingsDir, filename);
+      Deno.writeTextFileSync(filePath, JSON.stringify(asset.paperVotings, null, 2));
+    }
+    return generatedFilenames;
+  }
+
+  private removeStalePaperVotingsFiles(generatedFilenames: Set<string>): void {
+    for (const entry of Deno.readDirSync(this.paperVotingsDir)) {
+      const isStalePaperVotingsFile = entry.isFile &&
+        /^paper-votings-.*\.json$/.test(entry.name) &&
+        !generatedFilenames.has(entry.name);
+      if (isStalePaperVotingsFile) {
+        Deno.removeSync(path.join(this.paperVotingsDir, entry.name));
+      }
     }
   }
 }

--- a/src/scripts/generate-paper-votings/paper-votings-writer.ts
+++ b/src/scripts/generate-paper-votings/paper-votings-writer.ts
@@ -1,0 +1,20 @@
+import * as path from '@std/path';
+import { PaperVotingsAssetDto } from './model.ts';
+
+export interface PaperVotingsWriter {
+  writePaperVotings(assets: PaperVotingsAssetDto[]): void;
+}
+
+export class PaperVotingsFileWriter implements PaperVotingsWriter {
+  constructor(private readonly paperVotingsDir: string) {
+  }
+
+  writePaperVotings(assets: PaperVotingsAssetDto[]): void {
+    Deno.mkdirSync(this.paperVotingsDir, { recursive: true });
+
+    for (const asset of assets) {
+      const filename = path.join(this.paperVotingsDir, `paper-votings-${asset.batchNo}.json`);
+      Deno.writeTextFileSync(filename, JSON.stringify(asset.paperVotings, null, 2));
+    }
+  }
+}

--- a/src/scripts/generate-paper-votings/period-data-store.ts
+++ b/src/scripts/generate-paper-votings/period-data-store.ts
@@ -1,0 +1,69 @@
+import * as path from '@std/path';
+import { Registry } from '@srw-astro/models/registry';
+import { SessionScan } from '@srw-astro/models/session-scan';
+import { VotingPaperMap } from '@srw-astro/models/oparl-derivatives';
+
+export type PeriodData = {
+  registry: Registry;
+  votingPaperMap: VotingPaperMap;
+  sessionScansByDate: { [sessionDate: string]: SessionScan };
+};
+
+export interface PeriodDataStore {
+  loadPeriods(): PeriodData[];
+}
+
+export class PeriodDataFileStore implements PeriodDataStore {
+  constructor(private readonly dataDir: string) {
+  }
+
+  public loadPeriods(): PeriodData[] {
+    const periods: PeriodData[] = [];
+
+    for (const entry of Deno.readDirSync(this.dataDir)) {
+      if (!entry.isDirectory) {
+        continue;
+      }
+
+      const periodDir = path.join(this.dataDir, entry.name);
+      const registry = this.readJsonFile<Registry>(path.join(periodDir, 'registry.json'));
+      if (!registry) {
+        continue;
+      }
+
+      periods.push({
+        registry,
+        votingPaperMap: this.readJsonFile<VotingPaperMap>(path.join(periodDir, 'voting-paper-map.json')) ?? {},
+        sessionScansByDate: this.loadSessionScansByDate(periodDir, registry),
+      });
+    }
+
+    // Sorted by the canonical registry id for a deterministic processing order across runs.
+    return periods.toSorted((a, b) => a.registry.id.localeCompare(b.registry.id));
+  }
+
+  private loadSessionScansByDate(periodDir: string, registry: Registry): { [sessionDate: string]: SessionScan } {
+    const sessionScansByDate: { [sessionDate: string]: SessionScan } = {};
+
+    for (const session of registry.sessions) {
+      const sessionScanPath = path.join(periodDir, session.date, `session-scan-${session.date}.json`);
+      const sessionScan = this.readJsonFile<SessionScan>(sessionScanPath);
+      if (sessionScan) {
+        sessionScansByDate[session.date] = sessionScan;
+      }
+    }
+
+    return sessionScansByDate;
+  }
+
+  private readJsonFile<T>(filePath: string): T | null {
+    try {
+      return JSON.parse(Deno.readTextFileSync(filePath)) as T;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Why

Second step of the »Abstimmungen« tab on the paper detail page (epic #458, spec `docs/wayfinder/448-abstimmungen-tab-spec.md` §4–6, §9).

The link from a voting to a paper only exists **forwards** (`{period}/voting-paper-map.json`: session date → agenda item → paper id), and the faction/person breakdown only existed inside the SSR session page. Neither is reachable from the client-rendered paper page. This reverses the map at build time and resolves every vote to its person and faction, emitting self-contained batched assets the client can just fetch and render.

## What changed

- **New generator** `src/scripts/generate-paper-votings/` — follows the sibling pattern (`cli.ts` + `index.ts` + generator + writer + store + `acceptance-tests/`).
- **11 BDD acceptance scenarios** covering the map×scan intersection (both directions), multi-scans, cross-period merge, counts/accepted, sorting, batching/`padStart`, and the strict person join.
- `docker/generate-paper-votings.Dockerfile` + a HOWTO section.
- **Shared-module follow-up** (2nd commit): `getVotingId` and `getVoteCounts` moved into `astro/src/models/voting-breakdown.ts`; `session-utils.ts` re-exports `getVotingId` so its callers are unchanged.

## Verified against real data, not just tests

All three samples the ticket names, checked against the raw scans:

| Sample | Result |
|---|---|
| `239123` (cross-period) | 2 rows: `magdeburg-8/2024-10-17/47`, then `magdeburg-7/2022-09-01/73` |
| `243686` (multi-scan) | votings `12` and `14` on TOP 12.6, not deduplicated |
| `200510` (no votings) | absent entirely — 5434 of 7393 papers have no votings |

The cross-period case demonstrates the per-period registry join: `239123` resolves to a different lead faction in each period (`CDU/FDP` in P8, `GRÜNE/future!` in P7).

Output is **deterministic** — two runs produce byte-identical files (2765 papers, 122 batches). The Docker container, run exactly as the HOWTO documents, produced output matching the local run file-for-file.

## Notes for the reviewer

**The review caught two real drift risks (2nd commit).** I first re-implemented `getVotingId` and wrote my own J/N/E/O tally. But `voting-breakdown.ts` already had a private `countVotes` — so `accepted` and `counts` were computed by *two* implementations of one rule — and the voting id drives the deep-link URL, so a filename-convention change would silently break links. Both now live in the shared module and `votingAccepted` derives from the same counts. Generator output is unchanged after the refactor; the Astro build still produces all 4034 pages.

**Deliberately kept** (flagged in review, all pinned by spec §4): the `J/N/E/O` count keys (these are the domain's actual vote codes — `VoteResult.VOTE_FOR = 'J'`), and the `sessionId` + `date` pair. `getBatchNo` is left local because deduplicating it would mean editing an untouched sibling generator.

**Pipeline order:** the HOWTO places this **after** video processing, not just after the OParl derivates — it needs `session-scan-*.json` as well as `voting-paper-map.json`.

**Possible follow-up:** `+filename.substring(11, 14)` still has copies in `_helpers.ts`, `_motions.astro`, and `votings-image-data-generator.ts` that could now point at the shared `getVotingId`.

**Checks:** `deno fmt`/`lint`/`check src/`/`test` (12 files, 129 steps) and `npm run format:check`/`npm test` (54 passing)/`astro check` (0 errors, 0 warnings, 0 hints) all green.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generation of paper-specific voting assets including vote counts, acceptance status, session metadata, and faction breakdowns.
  * Introduced a `generate-paper-votings` CLI and Docker workflow producing deterministic, batch-based outputs (with cleanup of stale batch files).
* **Documentation**
  * Documented the new mandatory `generate-paper-votings` build step and how it maps scanned agenda items to per-paper votings.
* **Bug Fixes**
  * Improved vote counting/acceptance logic to aggregate “for vs against” and treat unrecognized votes as “not voted”.
* **Tests**
  * Added unit/acceptance coverage for vote counting rules, filtering, sorting, batching, and missing-person failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->