### PR TITLE
feat(paper-votings): render Abstimmungen tab on paper detail page (#456)

### DIFF
--- a/astro/src/models/paper-votings.ts
+++ b/astro/src/models/paper-votings.ts
@@ -1,0 +1,20 @@
+import type { VoteCounts, VotesByFaction } from './voting-breakdown.ts';
+
+export type PaperVotingItem = {
+  parliamentPeriodId: string;
+  sessionId: string;
+  date: string;
+  votingId: number;
+  agendaItem: string;
+  title: string;
+  type: string;
+  accepted: boolean;
+  counts: VoteCounts;
+  votesByFactions: VotesByFaction[];
+};
+
+// Sorted by the generator: date descending, then votingId ascending.
+export type PaperVotingsDto = {
+  paperId: number;
+  votings: PaperVotingItem[];
+};

--- a/astro/src/pages/paper/_helpers.test.ts
+++ b/astro/src/pages/paper/_helpers.test.ts
@@ -3,7 +3,6 @@ import {
   getVoteStatusClass,
   selectPaperVotings,
   spansMultipleParliamentPeriods,
-  toBatchNo,
   toPaperVotingViews,
 } from './_helpers.ts';
 import type {
@@ -29,19 +28,6 @@ function paperVotingItem(
     ...overrides,
   };
 }
-
-describe('toBatchNo', () => {
-  test('groups papers into batches of 100', () => {
-    assert.equal(toBatchNo(236011), '2360');
-    assert.equal(toBatchNo(236099), '2360');
-    assert.equal(toBatchNo(236100), '2361');
-  });
-
-  test('pads batch numbers to four digits', () => {
-    assert.equal(toBatchNo(0), '0000');
-    assert.equal(toBatchNo(4711), '0047');
-  });
-});
 
 describe('selectPaperVotings', () => {
   test('returns the votings of the matching paper', () => {

--- a/astro/src/pages/paper/_helpers.test.ts
+++ b/astro/src/pages/paper/_helpers.test.ts
@@ -1,0 +1,146 @@
+import { assert, describe, test } from 'vitest';
+import {
+  getVoteStatusClass,
+  selectPaperVotings,
+  spansMultipleParliamentPeriods,
+  toBatchNo,
+  toPaperVotingViews,
+} from './_helpers.ts';
+import type {
+  PaperVotingItem,
+  PaperVotingsDto,
+} from '@models/paper-votings.ts';
+import { VoteResult } from '@models/Session.ts';
+
+function paperVotingItem(
+  overrides: Partial<PaperVotingItem> = {},
+): PaperVotingItem {
+  return {
+    parliamentPeriodId: 'magdeburg-8',
+    sessionId: '2024-07-08',
+    date: '2024-07-08',
+    votingId: 12,
+    agendaItem: '12.6',
+    title: 'Ein Antrag',
+    type: 'Antrag',
+    accepted: true,
+    counts: { J: 30, N: 10, E: 2, O: 5 },
+    votesByFactions: [],
+    ...overrides,
+  };
+}
+
+describe('toBatchNo', () => {
+  test('groups papers into batches of 100', () => {
+    assert.equal(toBatchNo(236011), '2360');
+    assert.equal(toBatchNo(236099), '2360');
+    assert.equal(toBatchNo(236100), '2361');
+  });
+
+  test('pads batch numbers to four digits', () => {
+    assert.equal(toBatchNo(0), '0000');
+    assert.equal(toBatchNo(4711), '0047');
+  });
+});
+
+describe('selectPaperVotings', () => {
+  test('returns the votings of the matching paper', () => {
+    const votings = [paperVotingItem()];
+    const batch: PaperVotingsDto[] = [
+      { paperId: 236010, votings: [paperVotingItem({ votingId: 99 })] },
+      { paperId: 236011, votings },
+    ];
+
+    assert.deepEqual(selectPaperVotings(batch, 236011), votings);
+  });
+
+  test('returns an empty array when the paper has no entry in the batch', () => {
+    const batch: PaperVotingsDto[] = [{ paperId: 236010, votings: [] }];
+    assert.deepEqual(selectPaperVotings(batch, 236011), []);
+  });
+
+  test('returns an empty array for an empty batch', () => {
+    assert.deepEqual(selectPaperVotings([], 236011), []);
+  });
+});
+
+describe('spansMultipleParliamentPeriods', () => {
+  test('is false when all votings come from a single parliament period', () => {
+    const votings = [
+      paperVotingItem({ parliamentPeriodId: 'magdeburg-8' }),
+      paperVotingItem({ parliamentPeriodId: 'magdeburg-8', votingId: 13 }),
+    ];
+    assert.isFalse(spansMultipleParliamentPeriods(votings));
+  });
+
+  test('is true when votings span more than one parliament period', () => {
+    const votings = [
+      paperVotingItem({ parliamentPeriodId: 'magdeburg-7' }),
+      paperVotingItem({ parliamentPeriodId: 'magdeburg-8' }),
+    ];
+    assert.isTrue(spansMultipleParliamentPeriods(votings));
+  });
+
+  test('is false when there are no votings', () => {
+    assert.isFalse(spansMultipleParliamentPeriods([]));
+  });
+});
+
+describe('toPaperVotingViews', () => {
+  test('adds a localised session date for display', () => {
+    const [view] = toPaperVotingViews([
+      paperVotingItem({ date: '2024-07-08' }),
+    ]);
+    assert.equal(view.dateDisplay, '08.07.2024');
+  });
+
+  test('labels the period badge with the period number', () => {
+    const [view] = toPaperVotingViews([
+      paperVotingItem({ parliamentPeriodId: 'magdeburg-8' }),
+    ]);
+    assert.equal(view.periodBadgeLabel, 'WP 8');
+  });
+
+  test('falls back to the raw period id when it carries no period number', () => {
+    const [view] = toPaperVotingViews([
+      paperVotingItem({ parliamentPeriodId: 'test-period' }),
+    ]);
+    assert.equal(view.periodBadgeLabel, 'test-period');
+  });
+
+  test('preserves the order and payload of the generated votings', () => {
+    const votings = [
+      paperVotingItem({ votingId: 14 }),
+      paperVotingItem({ votingId: 12 }),
+    ];
+    const views = toPaperVotingViews(votings);
+
+    assert.deepEqual(
+      views.map((view) => view.votingId),
+      [14, 12],
+    );
+    assert.equal(views[0].title, votings[0].title);
+    assert.deepEqual(views[0].counts, votings[0].counts);
+  });
+});
+
+describe('getVoteStatusClass', () => {
+  test('maps each cast vote to its status colour', () => {
+    assert.equal(getVoteStatusClass(VoteResult.VOTE_FOR), 'status-success');
+    assert.equal(getVoteStatusClass(VoteResult.VOTE_AGAINST), 'status-error');
+    assert.equal(
+      getVoteStatusClass(VoteResult.VOTE_ABSTENTION),
+      'status-warning',
+    );
+  });
+
+  // The session page leaves non-votes unmodified, which daisyUI renders as a
+  // faint neutral dot; adding status-neutral would make them solid instead.
+  test('leaves non-votes unmodified, like the session page does', () => {
+    assert.equal(getVoteStatusClass(VoteResult.DID_NOT_VOTE), '');
+  });
+
+  test('leaves unknown vote codes unmodified', () => {
+    assert.equal(getVoteStatusClass('?'), '');
+  });
+});

--- a/astro/src/pages/paper/_helpers.ts
+++ b/astro/src/pages/paper/_helpers.ts
@@ -1,0 +1,59 @@
+import type {
+  PaperVotingItem,
+  PaperVotingsDto,
+} from '@models/paper-votings.ts';
+import { VoteResult } from '@models/Session.ts';
+import { formatDate } from '@utils/format-date.ts';
+
+export type PaperVotingView = PaperVotingItem & {
+  dateDisplay: string;
+  periodBadgeLabel: string;
+};
+
+const papersPerBatch = 100;
+const batchNoLength = 4;
+const periodNumberPattern = /-(\d+)$/;
+
+// Only cast votes get a colour; anything else keeps daisyUI's faint default
+// dot, matching how the session page renders the same breakdown.
+const voteStatusClasses = new Map<string, string>([
+  [VoteResult.VOTE_FOR, 'status-success'],
+  [VoteResult.VOTE_AGAINST, 'status-error'],
+  [VoteResult.VOTE_ABSTENTION, 'status-warning'],
+]);
+
+export function toBatchNo(paperId: number): string {
+  return `${Math.floor(paperId / papersPerBatch)}`.padStart(batchNoLength, '0');
+}
+
+export function selectPaperVotings(
+  batch: PaperVotingsDto[],
+  paperId: number,
+): PaperVotingItem[] {
+  return batch.find((entry) => entry.paperId === paperId)?.votings ?? [];
+}
+
+export function spansMultipleParliamentPeriods(
+  votings: PaperVotingItem[],
+): boolean {
+  return new Set(votings.map((voting) => voting.parliamentPeriodId)).size > 1;
+}
+
+function toPeriodBadgeLabel(parliamentPeriodId: string): string {
+  const periodNumber = parliamentPeriodId.match(periodNumberPattern)?.[1];
+  return periodNumber ? `WP ${periodNumber}` : parliamentPeriodId;
+}
+
+export function toPaperVotingViews(
+  votings: PaperVotingItem[],
+): PaperVotingView[] {
+  return votings.map((voting) => ({
+    ...voting,
+    dateDisplay: formatDate(voting.date),
+    periodBadgeLabel: toPeriodBadgeLabel(voting.parliamentPeriodId),
+  }));
+}
+
+export function getVoteStatusClass(vote: string): string {
+  return voteStatusClasses.get(vote) ?? '';
+}

--- a/astro/src/pages/paper/_helpers.ts
+++ b/astro/src/pages/paper/_helpers.ts
@@ -10,8 +10,6 @@ export type PaperVotingView = PaperVotingItem & {
   periodBadgeLabel: string;
 };
 
-const papersPerBatch = 100;
-const batchNoLength = 4;
 const periodNumberPattern = /-(\d+)$/;
 
 // Only cast votes get a colour; anything else keeps daisyUI's faint default
@@ -21,10 +19,6 @@ const voteStatusClasses = new Map<string, string>([
   [VoteResult.VOTE_AGAINST, 'status-error'],
   [VoteResult.VOTE_ABSTENTION, 'status-warning'],
 ]);
-
-export function toBatchNo(paperId: number): string {
-  return `${Math.floor(paperId / papersPerBatch)}`.padStart(batchNoLength, '0');
-}
 
 export function selectPaperVotings(
   batch: PaperVotingsDto[],

--- a/astro/src/pages/paper/index.astro
+++ b/astro/src/pages/paper/index.astro
@@ -131,6 +131,88 @@ import Layout from '@layouts/Layout.astro';
         <input
           role="tab"
           class="tab"
+          aria-label="Abstimmungen"
+          type="radio"
+          name="paper-tabs-radio"
+          x-bind:disabled="paperVotings.length === 0"
+        />
+        <div class="tab-content border-base-200 bg-base-100 p-6">
+          <div class="space-y-4">
+            <template
+              x-for="voting in paperVotings"
+              :key="`${voting.parliamentPeriodId}-${voting.sessionId}-${voting.votingId}`"
+            >
+              <a
+                :href="`/pp/${voting.parliamentPeriodId}/session/${voting.sessionId}/voting/${voting.votingId}`"
+                class="card card-border border-base-300 bg-base-100 hover:bg-base-200 hover:cursor-pointer block"
+              >
+                <div class="card-body space-y-2">
+                  <div
+                    class="text-base-content/70 flex flex-wrap items-center gap-2 text-sm"
+                  >
+                    <span
+                      x-show="showPeriodBadge"
+                      class="badge badge-outline badge-sm"
+                      x-text="voting.periodBadgeLabel"></span>
+                    <span x-text="voting.dateDisplay"></span>
+                    <span x-text="`TOP ${voting.agendaItem}`"></span>
+                    <span
+                      x-show="voting.type"
+                      class="badge badge-neutral badge-sm"
+                      x-text="voting.type"></span>
+                    <span
+                      class="badge badge-sm"
+                      :class="voting.accepted ? 'badge-success' : 'badge-error'"
+                      x-text="voting.accepted ? 'angenommen' : 'abgelehnt'"
+                    ></span>
+                  </div>
+
+                  <div class="text-base" x-text="voting.title"></div>
+
+                  <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                    <span class="text-success" x-text="`${voting.counts.J} Ja`"
+                    ></span>
+                    <span class="text-error" x-text="`${voting.counts.N} Nein`"
+                    ></span>
+                    <span
+                      class="text-warning"
+                      x-text="`${voting.counts.E} Enth.`"></span>
+                    <span
+                      class="text-base-content/60"
+                      x-text="`${voting.counts.O} —`"></span>
+                  </div>
+
+                  <div class="grid sm:grid-cols-[auto_1fr] sm:gap-x-2">
+                    <template x-for="votesByFaction in voting.votesByFactions">
+                      <div class="contents">
+                        <div
+                          class="text-base-content/70"
+                          x-text="`${votesByFaction.factionName}:`"
+                        >
+                        </div>
+                        <div class="space-x-1 mb-1">
+                          <template x-for="vote in votesByFaction.votes">
+                            <div class="tooltip" :data-tip="vote.personName">
+                              <div
+                                class="status status-lg"
+                                :class="voteStatusClass(vote.vote)"
+                              >
+                              </div>
+                            </div>
+                          </template>
+                        </div>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </a>
+            </template>
+          </div>
+        </div>
+
+        <input
+          role="tab"
+          class="tab"
           aria-label="Zugehörige Drucksachen"
           type="radio"
           name="paper-tabs-radio"
@@ -150,6 +232,15 @@ import Layout from '@layouts/Layout.astro';
   import Alpine from 'alpinejs';
   import { AWS_CLOUDFRONT_BASE_URL } from 'astro:env/client';
   import { toPaperBatchNo } from '@models/paper-batch.ts';
+  import type { PaperVotingsDto } from '@models/paper-votings.ts';
+  import {
+    getVoteStatusClass,
+    selectPaperVotings,
+    spansMultipleParliamentPeriods,
+    toBatchNo,
+    toPaperVotingViews,
+    type PaperVotingView,
+  } from './_helpers.ts';
 
   type PaperFile = {
     id: number;
@@ -241,6 +332,9 @@ import Layout from '@layouts/Layout.astro';
         superordinatedPaperIds: [],
       } as Paper,
       paperTree: null as PaperTree | null,
+      paperVotings: [] as PaperVotingView[],
+      showPeriodBadge: false,
+      voteStatusClass: getVoteStatusClass,
       selectedFile: null as number | null,
       documentUrl: null as string | null,
       fileSizeOk: true,
@@ -279,6 +373,8 @@ import Layout from '@layouts/Layout.astro';
           paper.files.length > 0 && (paper.files[0].size || 0) <= 1024 * 1024;
         this.fileSizeDisplay = formatFileSize(paper.files[0].size || 0);
 
+        await this.loadPaperVotings(paperId);
+
         const paperGraphBatchNo = toPaperBatchNo(paper.rootPaperId);
 
         const paperGraphBatchResponse = await fetch(
@@ -298,6 +394,24 @@ import Layout from '@layouts/Layout.astro';
         }
 
         this.paperTree = createPaperTree(paperGraph, paperGraph.rootPaperId);
+      },
+      // Papers without scanned votings have no asset at all, so a missing batch
+      // is expected and leaves the tab disabled rather than raising an error.
+      async loadPaperVotings(paperId: number) {
+        try {
+          const response = await fetch(
+            `${AWS_CLOUDFRONT_BASE_URL}/web-assets/paper-votings/paper-votings-${toBatchNo(paperId)}.json`,
+          );
+          if (!response.ok) return;
+
+          const batch = (await response.json()) as PaperVotingsDto[];
+          const votings = selectPaperVotings(batch, paperId);
+
+          this.paperVotings = toPaperVotingViews(votings);
+          this.showPeriodBadge = spansMultipleParliamentPeriods(votings);
+        } catch {
+          return;
+        }
       },
       selectFile: function (fileId: number) {
         if (fileId) {

--- a/astro/src/pages/paper/index.astro
+++ b/astro/src/pages/paper/index.astro
@@ -237,7 +237,6 @@ import Layout from '@layouts/Layout.astro';
     getVoteStatusClass,
     selectPaperVotings,
     spansMultipleParliamentPeriods,
-    toBatchNo,
     toPaperVotingViews,
     type PaperVotingView,
   } from './_helpers.ts';
@@ -373,13 +372,14 @@ import Layout from '@layouts/Layout.astro';
           paper.files.length > 0 && (paper.files[0].size || 0) <= 1024 * 1024;
         this.fileSizeDisplay = formatFileSize(paper.files[0].size || 0);
 
-        await this.loadPaperVotings(paperId);
-
         const paperGraphBatchNo = toPaperBatchNo(paper.rootPaperId);
 
-        const paperGraphBatchResponse = await fetch(
-          `${AWS_CLOUDFRONT_BASE_URL}/web-assets/papers/paper-graphs-${paperGraphBatchNo}.json`,
-        );
+        const [, paperGraphBatchResponse] = await Promise.all([
+          this.loadPaperVotings(paperId),
+          fetch(
+            `${AWS_CLOUDFRONT_BASE_URL}/web-assets/papers/paper-graphs-${paperGraphBatchNo}.json`,
+          ),
+        ]);
         const paperGraphBatch =
           (await paperGraphBatchResponse.json()) as PaperGraph[];
         const paperGraph = paperGraphBatch.find(
@@ -400,7 +400,7 @@ import Layout from '@layouts/Layout.astro';
       async loadPaperVotings(paperId: number) {
         try {
           const response = await fetch(
-            `${AWS_CLOUDFRONT_BASE_URL}/web-assets/paper-votings/paper-votings-${toBatchNo(paperId)}.json`,
+            `${AWS_CLOUDFRONT_BASE_URL}/web-assets/paper-votings/paper-votings-${toPaperBatchNo(paperId)}.json`,
           );
           if (!response.ok) return;
 
@@ -409,8 +409,8 @@ import Layout from '@layouts/Layout.astro';
 
           this.paperVotings = toPaperVotingViews(votings);
           this.showPeriodBadge = spansMultipleParliamentPeriods(votings);
-        } catch {
-          return;
+        } catch (error) {
+          console.debug('Could not load paper votings.', error);
         }
       },
       selectFile: function (fileId: number) {

--- a/src/deps/astro/deno.json
+++ b/src/deps/astro/deno.json
@@ -5,6 +5,7 @@
     "./oparl": "./oparl.ts",
     "./oparl-derivatives": "./oparl-derivatives.ts",
     "./paper-batch": "./paper-batch.ts",
+    "./paper-votings": "./paper-votings.ts",
     "./registry": "./registry.ts",
     "./session-input": "./session-input.ts",
     "./session-scan": "./session-scan.ts",

--- a/src/deps/astro/paper-votings.ts
+++ b/src/deps/astro/paper-votings.ts
@@ -1,0 +1,1 @@
+export * from '../../../astro/src/models/paper-votings.ts';

--- a/src/scripts/generate-paper-votings/acceptance-tests/scenario.test.ts
+++ b/src/scripts/generate-paper-votings/acceptance-tests/scenario.test.ts
@@ -3,9 +3,10 @@ import { assertEquals, assertThrows } from '@std/assert';
 import { PaperVotingsGenerator } from '../paper-votings-generator.ts';
 import { PeriodData, PeriodDataStore } from '../period-data-store.ts';
 import { PaperVotingsWriter } from '../paper-votings-writer.ts';
-import { PaperVotingsAssetDto, PaperVotingsDto } from '../model.ts';
+import { PaperVotingsAssetDto } from '../model.ts';
 import { Registry, RegistryFaction, RegistryPerson } from '@srw-astro/models/registry';
 import { SessionScan, SessionScanItem, SessionScanVote } from '@srw-astro/models/session-scan';
+import { PaperVotingsDto } from '@srw-astro/models/paper-votings';
 
 const PERIOD_7 = 'example-7';
 const PERIOD_8 = 'example-8';

--- a/src/scripts/generate-paper-votings/model.ts
+++ b/src/scripts/generate-paper-votings/model.ts
@@ -1,22 +1,6 @@
-import { VoteCounts, VotesByFaction } from '@srw-astro/models/voting-breakdown';
+import type { PaperVotingsDto } from '@srw-astro/models/paper-votings';
 
-export type PaperVotingItem = {
-  parliamentPeriodId: string;
-  sessionId: string;
-  date: string;
-  votingId: number;
-  agendaItem: string;
-  title: string;
-  type: string;
-  accepted: boolean;
-  counts: VoteCounts;
-  votesByFactions: VotesByFaction[];
-};
-
-export type PaperVotingsDto = {
-  paperId: number;
-  votings: PaperVotingItem[];
-};
+export type { PaperVotingItem, PaperVotingsDto } from '@srw-astro/models/paper-votings';
 
 export type PaperVotingsAssetDto = {
   batchNo: string;

--- a/src/scripts/generate-paper-votings/model.ts
+++ b/src/scripts/generate-paper-votings/model.ts
@@ -1,7 +1,5 @@
 import type { PaperVotingsDto } from '@srw-astro/models/paper-votings';
 
-export type { PaperVotingItem, PaperVotingsDto } from '@srw-astro/models/paper-votings';
-
 export type PaperVotingsAssetDto = {
   batchNo: string;
   paperVotings: PaperVotingsDto[];

--- a/src/scripts/generate-paper-votings/paper-votings-generator.ts
+++ b/src/scripts/generate-paper-votings/paper-votings-generator.ts
@@ -4,7 +4,8 @@ import { SessionScanItem } from '@srw-astro/models/session-scan';
 import { Registry } from '@srw-astro/models/registry';
 import { PeriodData, PeriodDataStore } from './period-data-store.ts';
 import { PaperVotingsWriter } from './paper-votings-writer.ts';
-import { PaperVotingItem, PaperVotingsAssetDto, PaperVotingsDto } from './model.ts';
+import { PaperVotingsAssetDto } from './model.ts';
+import { PaperVotingItem, PaperVotingsDto } from '@srw-astro/models/paper-votings';
 
 export class PaperVotingsGenerator {
   constructor(


### PR DESCRIPTION
Closes #456. Implements the spec in `docs/wayfinder/452-abstimmungen-tab-client.md` (§8 of the map in #448), on top of the generator from #455/#460.

## What changed

A new **»Abstimmungen«** tab on the client-rendered paper page listing every scanned voting for that paper as a standalone card.

- **Load.** The paper-votings batch asset is fetched in `init()` concurrently with the paper-graph asset (`Promise.all`), keyed by the shared `toPaperBatchNo` from #462. The tab’s disabled-when-empty state is therefore correct on first paint — no separate existence check. A missing batch (404) or no `find` hit yields `paperVotings = []` with no error message, matching »Zugehörige Drucksachen«.
- **Cards.** Whole card is an `<a>` to `/pp/{parliamentPeriodId}/session/{sessionId}/voting/{votingId}`. Head (period badge · date · TOP · `type` · result pill), title, counter row from the precomputed `counts`, and the faction/person breakdown with the person name as tooltip. No timeline chrome, no »Nur Sachbeschlüsse« filter. Order is render-only — the asset arrives sorted.
- **Period badge** appears only when a paper’s votings span more than one parliament period.

## Deviation from the ticket, on purpose

The ticket asked for `PaperVotingsDto` / `PaperVotingItem` inline in the `<script>` block. The Deno generator already defined that same wire contract in `src/scripts/generate-paper-votings/model.ts`, so duplicating it would let a generator change silently break the client.

Instead the contract is canonical in `astro/src/models/paper-votings.ts` and consumed by the Deno generator through the `@srw-astro/models` workspace bridge, per CLAUDE.md (*"Define canonical model changes in `astro/src/models/`"*). It matches `docs/wayfinder/451-paper-votings-schema.md` field-for-field. The generator-internal batching envelope (`PaperVotingsAssetDto`, never seen by the browser) correctly stays local.

## Review findings, fixed

Two review passes (correctness + code quality) ran over the diff. Fixed here:

- **Serialized fetches.** `await loadPaperVotings(...)` gated the independent paper-graph fetch, delaying the »Zugehörige Drucksachen« tab by a full round-trip. Now `Promise.all`. Verified: the two requests start 0.1 ms apart and overlap.
- **Duplicated batch rule.** After rebasing onto #462, this file used the shared `toPaperBatchNo` for papers but a local `toBatchNo` for votings — the same rule twice in one file. Local copy and its tests removed.
- **Silent catch.** The catch only fires for network errors or malformed payloads (a missing batch is caught by the response check above), and those vanished without diagnostics. Now `console.debug`, matching the `console.error` parity elsewhere in `init()`.

Also caught earlier: non-votes were mapped to `status-neutral`, which daisyUI renders as a **solid** `var(--color-neutral)` rather than the faint `.status` default — non-voters would have rendered heavier than the votes that carry meaning, and differed from the session page for the same voting. Fixed to leave non-votes unmodified.

## Verification

The asset is **not on CloudFront yet** (403), so a plain `npm run dev` shows the tab permanently disabled and proves nothing. I served the generator’s real `output/paper-votings/` output against stub paper records and drove the page:

| Case | Result |
| --- | --- |
| Cross-period paper (243970) | 3 cards, WP 8 / WP 8 / WP 7 badges, newest-first, `votingId` ascending within session, per-period deep links correct |
| Single-period paper (236011) | Period badge in DOM but hidden; type + result badges visible |
| Paper without votings (237000) | Tab disabled, no cards, no console error, other tabs unaffected |
| Vote dots | `status-success` / `-error` / `-warning`, non-votes bare `status status-lg`; tooltips are person names |
| Fetch overlap | paper-votings and paper-graphs start 0.1 ms apart |

`npm run format:check` ✓ · `astro check` 0 errors ✓ · 74 vitest tests ✓ · `deno fmt --check` / `lint` / `check src/` / `test -A` ✓

## Notes for the reviewer

- **Deploy order:** the tab stays disabled everywhere until the paper-votings assets are published to CloudFront. Degrades cleanly until then.
- `docs/wayfinder/452` mentions a "Sitzungs-Hinweis" in the card head; issue #456’s own head enumeration omits it, so I followed the ticket. Easy to add if wanted.
- **Left for follow-up (not yet filed):** the vote→status-class mapping now exists in three spellings across the codebase (`_helpers.ts` keyed off `VoteResult`, plus magic strings in `_votings.astro` and the voting detail page), and `renderLevel()` on this page is a pre-existing `x-html` XSS sink fed by OParl paper titles. Neither is introduced by this PR.
- **Open question, not addressed:** `PaperVotingItem` carries both `sessionId` and `date`, always identical (`sessionId: sessionDate, date: sessionDate` in the generator). Worth collapsing or documenting, but it changes the wire contract and means regenerating assets — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **“Abstimmungen”** tab to paper pages with voting cards populated from asynchronously loaded voting data.
  * Cards show session date, agenda/type details, acceptance status, vote counts, and per-faction vote indicators.
  * Voting cards link to their detail pages; the tab is disabled when no voting data is available (missing assets fail silently).
* **Bug Fixes**
  * Improved period badge labeling and vote-status indicator mapping.
* **Tests**
  * Added unit coverage for selection, formatting, multi-period detection, and vote-status class resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
