### PR TITLE
refactor(paper-batch): extract batch number computation into shared model

### DIFF
--- a/astro/src/models/paper-batch.test.ts
+++ b/astro/src/models/paper-batch.test.ts
@@ -1,0 +1,45 @@
+import { assert, describe, test } from 'vitest';
+import {
+  PAPER_BATCH_NO_DIGITS,
+  PAPER_BATCH_SIZE,
+  toPaperBatchNo,
+} from './paper-batch.ts';
+
+describe('toPaperBatchNo', () => {
+  test('puts the first paper id into batch zero', () => {
+    assert.equal(toPaperBatchNo(0), '0000');
+  });
+
+  test('keeps every id below the batch size in batch zero', () => {
+    assert.equal(toPaperBatchNo(1), '0000');
+    assert.equal(toPaperBatchNo(PAPER_BATCH_SIZE - 1), '0000');
+  });
+
+  test('starts a new batch once the batch size is reached', () => {
+    assert.equal(toPaperBatchNo(PAPER_BATCH_SIZE), '0001');
+    assert.equal(toPaperBatchNo(PAPER_BATCH_SIZE + 1), '0001');
+    assert.equal(toPaperBatchNo(2 * PAPER_BATCH_SIZE - 1), '0001');
+    assert.equal(toPaperBatchNo(2 * PAPER_BATCH_SIZE), '0002');
+  });
+
+  test('pads the batch number to a fixed width so filenames sort lexicographically', () => {
+    const batchNos = [0, 100, 1000, 10_000, 100_000].map(toPaperBatchNo);
+
+    assert.deepEqual(batchNos, ['0000', '0001', '0010', '0100', '1000']);
+    assert.deepEqual(batchNos.toSorted(), batchNos);
+  });
+
+  test('does not truncate batch numbers wider than the padding', () => {
+    assert.equal(toPaperBatchNo(1_000_000), '10000');
+  });
+
+  test('derives real paper ids from the published assets', () => {
+    assert.equal(toPaperBatchNo(11), '0000');
+    assert.equal(toPaperBatchNo(239_142), '2391');
+  });
+
+  test('exposes the contract the generators and the web client share', () => {
+    assert.equal(PAPER_BATCH_SIZE, 100);
+    assert.equal(PAPER_BATCH_NO_DIGITS, 4);
+  });
+});

--- a/astro/src/models/paper-batch.ts
+++ b/astro/src/models/paper-batch.ts
@@ -1,0 +1,12 @@
+// Papers are grouped into fixed-size batches so a paper page can fetch one asset file instead of a full index.
+// The generators write papers-{batchNo}.json, paper-graphs-{batchNo}.json and paper-votings-{batchNo}.json,
+// and the web client derives the same batchNo to locate them. Changing these values invalidates published assets.
+export const PAPER_BATCH_SIZE = 100;
+export const PAPER_BATCH_NO_DIGITS = 4;
+
+export function toPaperBatchNo(paperId: number): string {
+  return `${Math.floor(paperId / PAPER_BATCH_SIZE)}`.padStart(
+    PAPER_BATCH_NO_DIGITS,
+    '0',
+  );
+}

--- a/astro/src/pages/paper/index.astro
+++ b/astro/src/pages/paper/index.astro
@@ -149,6 +149,7 @@ import Layout from '@layouts/Layout.astro';
 <script>
   import Alpine from 'alpinejs';
   import { AWS_CLOUDFRONT_BASE_URL } from 'astro:env/client';
+  import { toPaperBatchNo } from '@models/paper-batch.ts';
 
   type PaperFile = {
     id: number;
@@ -248,7 +249,7 @@ import Layout from '@layouts/Layout.astro';
         const queryParams = new URLSearchParams(location.search);
         const paperId = +(queryParams.get('paperId') || '0');
 
-        const batchNo = `${Math.floor(paperId / 100)}`.padStart(4, '0');
+        const batchNo = toPaperBatchNo(paperId);
 
         const batchResponse = await fetch(
           `${AWS_CLOUDFRONT_BASE_URL}/web-assets/papers/papers-${batchNo}.json`,
@@ -278,8 +279,7 @@ import Layout from '@layouts/Layout.astro';
           paper.files.length > 0 && (paper.files[0].size || 0) <= 1024 * 1024;
         this.fileSizeDisplay = formatFileSize(paper.files[0].size || 0);
 
-        const paperGraphBatchNo =
-          `${Math.floor(paper.rootPaperId / 100)}`.padStart(4, '0');
+        const paperGraphBatchNo = toPaperBatchNo(paper.rootPaperId);
 
         const paperGraphBatchResponse = await fetch(
           `${AWS_CLOUDFRONT_BASE_URL}/web-assets/papers/paper-graphs-${paperGraphBatchNo}.json`,

--- a/src/deps/astro/deno.json
+++ b/src/deps/astro/deno.json
@@ -4,6 +4,7 @@
   "exports": {
     "./oparl": "./oparl.ts",
     "./oparl-derivatives": "./oparl-derivatives.ts",
+    "./paper-batch": "./paper-batch.ts",
     "./registry": "./registry.ts",
     "./session-input": "./session-input.ts",
     "./session-scan": "./session-scan.ts",

--- a/src/deps/astro/paper-batch.ts
+++ b/src/deps/astro/paper-batch.ts
@@ -1,0 +1,1 @@
+export * from '../../../astro/src/models/paper-batch.ts';

--- a/src/scripts/generate-paper-assets/paper-assets-generator.ts
+++ b/src/scripts/generate-paper-assets/paper-assets-generator.ts
@@ -19,6 +19,7 @@ import {
   OparlAgendaItemsRepository,
 } from '../shared/oparl/oparl-agenda-items-repository.ts';
 import { OparlPaper } from '@srw-astro/models/oparl';
+import { toPaperBatchNo } from '@srw-astro/models/paper-batch';
 import { createInMemoryPaperGraph } from './paper-graph.ts';
 import { OparlObjectsStore } from '../shared/oparl/oparl-objects-store.ts';
 import { PaperAssetsWriter } from './paper-assets-writer.ts';
@@ -73,11 +74,10 @@ export class PaperAssetsGenerator {
         };
       },
     );
-    // Group papers in batches of 100.
     const paperAssetsGroups = papers
       .sort((a, b) => a.id - b.id)
       .reduce((acc, paper) => {
-        const batchNo = `${Math.floor(paper.id / 100)}`.padStart(4, '0');
+        const batchNo = toPaperBatchNo(paper.id);
         if (!acc[batchNo]) {
           acc[batchNo] = [];
         }
@@ -101,11 +101,10 @@ export class PaperAssetsGenerator {
           .filter((paper) => paper !== undefined);
         return { rootPaperId, papers: graphPapers };
       });
-    // Group paper graphs in batches of 100.
     const paperGraphGroups = paperGraphs
       .sort((a, b) => a.rootPaperId - b.rootPaperId)
       .reduce((acc, paperGraph) => {
-        const batchNo = `${Math.floor(paperGraph.rootPaperId / 100)}`.padStart(4, '0');
+        const batchNo = toPaperBatchNo(paperGraph.rootPaperId);
         if (!acc[batchNo]) {
           acc[batchNo] = [];
         }

--- a/src/scripts/generate-paper-votings/paper-votings-generator.ts
+++ b/src/scripts/generate-paper-votings/paper-votings-generator.ts
@@ -1,4 +1,5 @@
 import { getVoteCounts, getVotesByFactions, getVotingId, votingAccepted } from '@srw-astro/models/voting-breakdown';
+import { toPaperBatchNo } from '@srw-astro/models/paper-batch';
 import { SessionScanItem } from '@srw-astro/models/session-scan';
 import { Registry } from '@srw-astro/models/registry';
 import { PeriodData, PeriodDataStore } from './period-data-store.ts';
@@ -72,7 +73,7 @@ export class PaperVotingsGenerator {
     const paperVotingsByBatchNo = new Map<string, PaperVotingsDto[]>();
 
     for (const entry of paperVotings) {
-      const batchNo = getBatchNo(entry.paperId);
+      const batchNo = toPaperBatchNo(entry.paperId);
       const batch = paperVotingsByBatchNo.get(batchNo) ?? [];
       batch.push(entry);
       paperVotingsByBatchNo.set(batchNo, batch);
@@ -82,8 +83,4 @@ export class PaperVotingsGenerator {
       .map<PaperVotingsAssetDto>(([batchNo, entries]) => ({ batchNo, paperVotings: entries }))
       .toSorted((a, b) => a.batchNo.localeCompare(b.batchNo));
   }
-}
-
-function getBatchNo(paperId: number): string {
-  return `${Math.floor(paperId / 100)}`.padStart(4, '0');
 }


### PR DESCRIPTION
## Why

The paper batch number is an **asset filename contract**. The Deno generators write `papers-{batchNo}.json`, `paper-graphs-{batchNo}.json` and `paper-votings-{batchNo}.json`; the paper page derives the same `batchNo` to locate them.

Both halves hardcoded the batch size (`100`) and the `padStart(4, '0')` formatting independently. Changing the batch size in a generator would have made the page fetch a filename that does not exist — no build-time error, no failing test, papers silently lose their data.

## What changed

`toPaperBatchNo()` now lives in `astro/src/models/paper-batch.ts` (per CLAUDE.md: canonical models live in `astro/src/models/`), re-exported to Deno through the `@srw-astro/models` workspace package following the existing `voting-breakdown.ts` pattern.

All call sites now use it:

- `astro/src/pages/paper/index.astro` — **two** copies (papers batch + paper-graphs batch)
- `src/scripts/generate-paper-votings/paper-votings-generator.ts` — replaced the local `getBatchNo()`
- `src/scripts/generate-paper-assets/paper-assets-generator.ts` — **two** copies (papers + paper graphs)

`grep` for `padStart(4, '0')` across `astro/src` and `src/` now returns nothing.

The batch size and padding width are exported as `PAPER_BATCH_SIZE` / `PAPER_BATCH_NO_DIGITS`, so the two `// Group papers in batches of 100.` comments were dropped — they would go stale the moment the constant changed. New unit tests in `astro/src/models/paper-batch.test.ts` cover batch boundaries, zero-padding, lexicographic filename sorting, and ids wider than the padding.

**No behaviour change** — emitted batch numbers are identical.

## Notes for the reviewer

Three points where the repo differed from what I expected going in, worth a look:

1. There was **no `toBatchNo()` helper** on the Astro side. The logic was inline in the client `<script>` of `paper/index.astro`, in **two** places. So this consolidates five copies, not three.
2. The paper page **never fetches `paper-votings-*.json`** — only `papers-*` and `paper-graphs-*`. The generator produces that filename but this page doesn't consume it, so the votings asset is currently write-only from the page's perspective. Flagging in case that's an unfinished thread rather than intentional.
3. Naming: `toPaperBatchNo` rather than `toBatchNo`, because the Deno call sites import it unqualified where bare `toBatchNo` sits ambiguously next to `BatchedDocumentsImporter` in `index-search`.

## Verification

All green: `npm run format:check`, `npx astro check` (0 errors), `npx vitest run` (61 passed), plus `deno fmt --check`, `deno lint`, `deno check src/`, `deno test -A` (12 passed / 129 steps).

`astro check` only proves the *type* alias resolves — it would not catch Vite failing to resolve `@models/` when bundling a client `<script>`, which is exactly where the risk lives. So I also ran a full `astro build`: 4034 pages built, the helper inlines into the client bundle as `function n(e){return\`${Math.floor(e/100)}\`.padStart(4,\`0\`)}`, and no unresolved `@models` specifier reaches `dist/`.

To confirm the fix actually binds both sides, I temporarily set `PAPER_BATCH_SIZE = 50`: the Deno generator's batching acceptance test failed **and** the client bundle flipped to `Math.floor(e/50)`. Both sides now move together, which is the property that was missing. That experiment was reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent paper batching for generated paper, graph, and voting assets.
  * Paper batch identifiers are zero-padded for predictable asset sorting and lookup.

* **Bug Fixes**
  * Improved consistency between generated assets and the web client when locating paper batches.

* **Tests**
  * Added coverage for batch boundaries, padding, large batch numbers, and published asset mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->