### PR TITLE
docs(web-assets): document the manual S3/CloudFront publishing path

### DIFF
--- a/docs/arc42/07-verteilungssicht/01-web-auslieferung.adoc
+++ b/docs/arc42/07-verteilungssicht/01-web-auslieferung.adoc
@@ -119,3 +119,22 @@ App --> Ratsinfo : HTTPS, PDF-Abruf
 | Projekt-Server (VPS)
 | Typesense-Collections (Drucksachen, Redebeiträge), gegen die der Browser sucht.
 |===
+
+== Veröffentlichung der Web-Assets
+
+Die Assets unter `web-assets/` (Drucksachen-Batches, `paper-votings`-Batches,
+Abstimmungs-PNGs) entstehen aus Generatorläufen auf der Maintainer-Maschine, nicht
+im Netlify-Build. Architektonisch folgt daraus: die Veröffentlichung der Assets ist
+von der Veröffentlichung der Website *entkoppelt*. Ein Push auf `main` rollt die
+Seite aus, erreicht den S3-Bucket aber nicht — die beiden Kanäle haben eigene
+Auslöser und können auseinanderlaufen.
+
+Zwei Prefixes im selben Bucket verhalten sich dabei gegensätzlich:
+
+* `oparl/` wird von `scrape-oparl --push` skriptgesteuert veröffentlicht,
+  inhaltsadressiert und unveränderlich — eine Invalidierung ist nie nötig.
+* `web-assets/` wird manuell hochgeladen, mit stabilen, in-place überschriebenen
+  Dateinamen — hier ist nach jedem Upload eine CloudFront-Invalidierung nötig.
+
+Der operative Weg (Klickpfad, Cache-Regeln, Verifikation) ist in
+`docs/guides/publishing-web-assets.md` dokumentiert.

--- a/docs/guides/HOWTO.md
+++ b/docs/guides/HOWTO.md
@@ -219,9 +219,6 @@ deno run \
   -o=output/paper-votings/
 ```
 
-The output directory needs **read** access too, not just write: after writing the batches the tool
-lists the directory to prune batch files that no longer have content.
-
 `-d`/`--data-dir` defaults to `data/`, so it can be omitted when run from the repository root.
 
 #### Build the docker image

--- a/docs/guides/HOWTO.md
+++ b/docs/guides/HOWTO.md
@@ -12,6 +12,7 @@ Run the processing pipeline in this order. The script sections below document in
 4. `generate-image-assets` - create voting visualization image assets from processed session data.
 5. `generate-paper-votings` - reverse the voting-paper-map against the session scans into the per-paper voting assets. Needs both the OParl derivates (step 2) and the scanned votings (step 3.2).
 6. `index-search` - rebuild the Typesense search index after all paper, speech, and asset data is available.
+7. Publish the generated web assets to S3/CloudFront - see [publishing-web-assets.md](publishing-web-assets.md). This is a **manual** step and is not part of any build: until it runs, the new assets do not exist in production.
 
 
 ### Parse Speakers
@@ -204,19 +205,22 @@ This tool builds the web assets behind the »Abstimmungen« tab on the paper det
 
 It scans `<data-dir>` for `{period-id}/registry.json` and intersects each period's `voting-paper-map.json` with the session scans: only agenda items that were **actually scanned** produce a voting, so papers that were never voted on do not appear in the output at all (which is what disables the tab). A paper voted on in several parliament periods collects the votings of all of them, each joined against its own registry.
 
-Output is batched by paper id (`paper-votings-{batch}.json`, `batch = paperId / 100`), stably sorted (session date descending, then voting id ascending), so a repeated run produces no diff. The files belong next to the other web assets on S3/CloudFront under `web-assets/paper-votings/`.
+Output is batched by paper id (`paper-votings-{batch}.json`, `batch = paperId / 100`), stably sorted (session date descending, then voting id ascending), so a repeated run produces no diff. The files belong next to the other web assets on S3/CloudFront under `web-assets/paper-votings/`; generating them does **not** publish them — see [publishing-web-assets.md](publishing-web-assets.md).
 
 Run this **after** the OParl derivates (`voting-paper-map.json`) and the video processing (`session-scan-*.json`) exist.
 
 #### Using the deno script
 ```shell
 deno run \
-  -R=data \
+  -R=data,output/paper-votings \
   -W=output/paper-votings \
   src/scripts/generate-paper-votings/index.ts \
   -d=data/ \
   -o=output/paper-votings/
 ```
+
+The output directory needs **read** access too, not just write: after writing the batches the tool
+lists the directory to prune batch files that no longer have content.
 
 `-d`/`--data-dir` defaults to `data/`, so it can be omitted when run from the repository root.
 

--- a/docs/guides/publishing-web-assets.md
+++ b/docs/guides/publishing-web-assets.md
@@ -1,0 +1,127 @@
+## Publishing web assets to S3/CloudFront
+
+The web application is built by Netlify from the `main` branch, but the large assets it fetches at
+runtime are **not** part of that build. They live in an S3 bucket behind the public CloudFront
+distribution (`AWS_CLOUDFRONT_BASE_URL`, e.g. `https://d2zk2bghxwzsug.cloudfront.net`) and are
+published separately, by hand.
+
+> **This is a manual, maintainer-only step.** There is no `aws s3 sync` in this repository, no
+> deployment workflow (`.github/workflows/ci.yml` is a quality gate only), and no other automation:
+> the files are uploaded through the **AWS S3 console**. Publishing is therefore not triggered by a
+> push and is decoupled from the website's release — newly generated assets stay invisible in
+> production until someone uploads them. See [Known gaps](#known-gaps) for the sharp edges this
+> creates.
+
+### What goes where
+
+Each prefix under `web-assets/` is a plain mirror of a local directory. Upload the directory's
+contents so the keys land directly under the prefix (no extra nesting).
+
+| Local source | S3 prefix | Produced by |
+| --- | --- | --- |
+| `data/papers/` (committed) | `web-assets/papers/` | `generate-paper-assets` |
+| `output/paper-votings/` (**not** committed) | `web-assets/paper-votings/` | `generate-paper-votings` |
+| `output/image-assets/{period}/` (**not** committed) | `web-assets/parliament-periods/{period}/` | `generate-image-assets` |
+
+`generate-image-assets` already writes the `images/votings/{sessionId}/` sub-tree itself, so the
+period directory is mirrored as-is. The voting id in the filename is zero-padded to three digits,
+giving keys like
+`web-assets/parliament-periods/magdeburg-8/images/votings/2024-10-17/2024-10-17-047.png`.
+
+The `oparl/` prefix in the same bucket is the one exception: it is **not** uploaded by hand. It is
+published by `scrape-oparl --push`, which is fully scripted and content-addressed. Do not touch it
+through the console. See [HOWTO.md](HOWTO.md#publish-the-snapshot-to-s3cloudfront---push).
+
+`web-assets/papers/` is the only prefix whose source is committed to git. `paper-votings` and the
+image assets are generated into `output/` (git-ignored), so they exist only on the machine that ran
+the generator — regenerate before uploading rather than relying on a stale local copy.
+
+### Publishing `paper-votings`
+
+1. Make sure the inputs are current: the OParl derivates (`data/{period}/voting-paper-map.json`) and
+   the session scans (`data/{period}/{date}/session-scan-*.json`) must already reflect the sessions
+   you want to appear. See the mandatory processing order in [HOWTO.md](HOWTO.md).
+2. Regenerate the assets by running `generate-paper-votings` — the command is in
+   [HOWTO.md](HOWTO.md#generate-paper-votings). The run is deterministic and prunes batch files that
+   no longer have content, so `output/paper-votings/` is a complete, authoritative picture of what
+   the prefix should contain — not an increment.
+3. In the S3 console, open the bucket behind the CloudFront distribution (the same bucket as
+   `OPARL_S3_BUCKET`) and navigate to `web-assets/paper-votings/`. Create the prefix on first publish.
+4. Upload **all** files from `output/paper-votings/`, overwriting existing objects. Keep the default
+   upload settings — see [Cache behaviour](#cache-behaviour) for why no metadata is set by hand.
+5. Delete any `paper-votings-*.json` objects that the generator no longer produces. The console does
+   not do this for you: an upload only adds and overwrites. A leftover batch file serves stale
+   votings forever, because the client trusts whatever batch it fetches.
+6. Invalidate and verify (below).
+
+Because batch filenames are derived from the paper id (`paper-votings-{batch}.json`, where `batch` is
+`paperId / 100` zero-padded to four digits — see `toPaperBatchNo` in
+`astro/src/models/paper-batch.ts`), they are **stable across runs** and are overwritten in place.
+Adding a paper to an existing batch changes that file's content but not its name.
+
+### Cache behaviour
+
+Existing web assets carry **no `Cache-Control` header at all** — neither the paper JSON batches nor
+the voting PNGs. Uploading through the console without setting metadata reproduces exactly that, so
+the correct action for `paper-votings` is to **set nothing**. It matches the other web assets, which
+is what we want; it is not an endorsement of the setup (see [Known gaps](#known-gaps)).
+
+With no explicit directive, CloudFront applies the distribution's **default TTL** and browsers fall
+back to heuristic freshness based on `Last-Modified`.
+
+The practical consequence: **an overwritten batch file needs a CloudFront invalidation.** This is the
+opposite of the `oparl/` prefix, where blobs are content-hashed and immutable and therefore never
+need one — do not carry that reasoning over to `web-assets/`. After re-uploading, invalidate the
+paths you touched:
+
+```text
+/web-assets/paper-votings/*
+```
+
+Without the invalidation, edge locations keep serving the previous batch until the default TTL
+expires, and the tab shows outdated votings (or none) in the meantime.
+
+### Verifying a publish
+
+A missing object under `web-assets/` returns **`403 Forbidden`**, not `404` — the bucket denies
+`s3:ListBucket`, so S3 reports `AccessDenied` rather than `NoSuchKey`. Do not read a 403 as a
+permissions regression.
+
+**Do not probe an arbitrary batch to check whether a publish worked.** Only batches that contain at
+least one voted-on paper exist at all — far fewer than the paper batches (122 vs. 486 at the time of
+writing). A 403 therefore has two very different meanings, and you cannot tell them apart from the
+status code:
+
+- the batch was never uploaded — a real problem; or
+- no paper in that batch has a scanned voting, so the generator correctly produced no such file —
+  permanent and expected.
+
+Pick the probe by checking `output/paper-votings/` first: a batch that does not exist locally must
+return 403 in production too. `239123` is a good probe, since it has votings in two parliament
+periods and therefore also exercises the cross-period path:
+
+```shell
+curl -sS -o /dev/null -D - \
+  "$AWS_CLOUDFRONT_BASE_URL/web-assets/paper-votings/paper-votings-2391.json"
+```
+
+Expected: `HTTP/2 200` with `content-type: application/json`. Then confirm the page itself renders
+the tab at `/paper?paperId=239123` (period badges visible, cards link to the voting detail pages).
+
+The client treats every non-OK response the same way — the »Abstimmungen« tab stays disabled and no
+error is surfaced. That makes a missed upload **silent**: it looks exactly like a paper that was
+never voted on. The page will not tell you the publish failed, so verify against a batch you know
+has content.
+
+### Known gaps
+
+These are accepted for now, not endorsed. The fix for all three is the same — script the upload,
+modelled on the already-scripted, tested `src/scripts/scrape-oparl/oparl-s3-publisher.ts` — and is
+tracked in [#463](https://github.com/JensWinter/StadtratWatch-web/issues/463).
+
+- **The upload is manual.** A console click-path is unversioned, unreviewable, and easy to get
+  half-right — forgetting step 5 leaves stale batch files serving old votings indefinitely.
+- **No explicit `Cache-Control`.** Freshness depends on the distribution's default TTL and on
+  remembering to invalidate by hand. A publisher should set the header explicitly.
+- **A missed upload is silent.** The client degrades to a disabled tab, which is indistinguishable
+  from a paper that was never voted on, so nothing surfaces the failure.

--- a/docs/guides/publishing-web-assets.md
+++ b/docs/guides/publishing-web-assets.md
@@ -96,9 +96,13 @@ status code:
 - no paper in that batch has a scanned voting, so the generator correctly produced no such file —
   permanent and expected.
 
-Pick the probe by checking `output/paper-votings/` first: a batch that does not exist locally must
-return 403 in production too. `239123` is a good probe, since it has votings in two parliament
-periods and therefore also exercises the cross-period path:
+Pick the probe by checking `output/paper-votings/` first, and probe a batch that **does** exist
+locally. Do not invert the rule: a locally-absent batch only returns 403 once step 5 has actually
+been done — if an obsolete object was left behind, it happily returns 200 and serves stale votings.
+A 200 for a batch with no local counterpart is therefore a *finding*, not a pass.
+
+`239123` is a good probe, since it has votings in two parliament periods and therefore also
+exercises the cross-period path:
 
 ```shell
 curl -sS -o /dev/null -D - \

--- a/docs/wayfinder/448-abstimmungen-tab-spec.md
+++ b/docs/wayfinder/448-abstimmungen-tab-spec.md
@@ -105,7 +105,7 @@ Neuer Ordner `src/scripts/generate-paper-votings/` nach dem Muster von `generate
 
 ## 7. Deployment des Assets
 
-Die Batch-Dateien landen im selben S3-Bucket/CloudFront wie `web-assets/papers/` und werden über **denselben operativen Upload-Weg** wie die bestehenden Paper-Assets nach `web-assets/paper-votings/` synchronisiert. ~~Weil der Client per `find` auf `paperId` sucht, ist keine CloudFront-Invalidierung pro Inhalt nötig, solange Batchdateien überschrieben werden~~ (ggf. Standard-Invalidierung wie bei den übrigen Web-Assets).
+Die Batch-Dateien landen im selben S3-Bucket/CloudFront wie `web-assets/papers/` und werden über **denselben operativen Upload-Weg** wie die bestehenden Paper-Assets nach `web-assets/paper-votings/` synchronisiert. ~~Weil der Client per `find` auf `paperId` sucht, ist keine CloudFront-Invalidierung pro Inhalt nötig, solange Batchdateien überschrieben werden (ggf. Standard-Invalidierung wie bei den übrigen Web-Assets).~~ Nach **jedem** Upload ist eine CloudFront-Invalidierung nötig — siehe Korrektur unten.
 
 > **Erledigt in [#457](https://github.com/JensWinter/StadtratWatch-web/issues/457).** Der Upload-Weg ist identifiziert und dokumentiert: **manueller Upload über die AWS-S3-Konsole**, siehe `docs/guides/publishing-web-assets.md`.
 >

--- a/docs/wayfinder/448-abstimmungen-tab-spec.md
+++ b/docs/wayfinder/448-abstimmungen-tab-spec.md
@@ -105,9 +105,11 @@ Neuer Ordner `src/scripts/generate-paper-votings/` nach dem Muster von `generate
 
 ## 7. Deployment des Assets
 
-Die Batch-Dateien landen im selben S3-Bucket/CloudFront wie `web-assets/papers/` und werden über **denselben operativen Upload-Weg** wie die bestehenden Paper-Assets nach `web-assets/paper-votings/` synchronisiert. Weil der Client per `find` auf `paperId` sucht, ist keine CloudFront-Invalidierung pro Inhalt nötig, solange Batchdateien überschrieben werden (ggf. Standard-Invalidierung wie bei den übrigen Web-Assets).
+Die Batch-Dateien landen im selben S3-Bucket/CloudFront wie `web-assets/papers/` und werden über **denselben operativen Upload-Weg** wie die bestehenden Paper-Assets nach `web-assets/paper-votings/` synchronisiert. ~~Weil der Client per `find` auf `paperId` sucht, ist keine CloudFront-Invalidierung pro Inhalt nötig, solange Batchdateien überschrieben werden~~ (ggf. Standard-Invalidierung wie bei den übrigen Web-Assets).
 
-> **Ausführungs-Notiz (keine offene Entscheidung):** Der genaue Sync-Mechanismus der `web-assets/`-Dateien ist nicht im Repo skriptiert (kein `aws s3 sync` im Code gefunden) — er ist operativ/CI-seitig. Vor dem Ausrollen den bestehenden Upload-Schritt der Paper-Assets identifizieren und `paper-votings/` dort anhängen.
+> **Erledigt in [#457](https://github.com/JensWinter/StadtratWatch-web/issues/457).** Der Upload-Weg ist identifiziert und dokumentiert: **manueller Upload über die AWS-S3-Konsole**, siehe `docs/guides/publishing-web-assets.md`.
+>
+> **Korrektur zur Invalidierung:** Die oben durchgestrichene Aussage ist falsch. Der `find` auf `paperId` betrifft nur, wie der Client *innerhalb* einer Batch-Datei sucht, und hat mit Edge-Caching nichts zu tun. Da die Batch-Dateinamen stabil sind, in-place überschrieben werden und die Web-Assets **keinen `Cache-Control`-Header** ausliefern, ist nach jedem Upload sehr wohl eine CloudFront-Invalidierung nötig — sonst liefern die Edges bis zum Ablauf der Default-TTL alte Daten. Der inhaltsadressierte `oparl/`-Prefix ist der Sonderfall, der ohne Invalidierung auskommt; diese Begründung darf nicht auf `web-assets/` übertragen werden.
 
 ## 8. Client-Implementierung (`astro/src/pages/paper/index.astro`)
 


### PR DESCRIPTION
Schließt #457 (§7 der Spec `docs/wayfinder/448-abstimmungen-tab-spec.md`).

## Worum es geht

#457 wollte die `paper-votings`-Assets in die Web-Asset-Auslieferung einbinden. Erste Aufgabe laut Ticket: den bestehenden Upload-Weg der Paper-Assets identifizieren.

**Ergebnis der Suche:** es gibt keinen. Kein `aws s3 sync` im Repo, kein Deploy-Workflow (`.github/workflows/ci.yml` ist ein reines Qualitäts-Gate), nichts in der Git-History, kein Nachbar-Repo. Der Weg ist ein **manueller Upload über die AWS-S3-Konsole** — bestätigt vom Maintainer.

**Und: AC 3 war bereits erfüllt.** Die `paper-votings`-Batches sind live und aktuell — 40 von 122 Batch-Dateien stimmen byte-genau mit der lokalen Generator-Ausgabe überein (`paper-votings-2391.json` → `HTTP/2 200`). Dieser PR schließt damit die *Dokumentations*-Lücke, nicht die Auslieferungs-Lücke.

## Änderungen

- **Neu: `docs/guides/publishing-web-assets.md`** — Runbook: welches lokale Verzeichnis auf welchen Prefix gespiegelt wird, der Klickpfad für `paper-votings`, Cache-Verhalten, Verifikation, bekannte Schwächen.
- **`docs/guides/HOWTO.md`** — Veröffentlichung als Schritt 7 der Pipeline ergänzt (mit dem Hinweis, dass sie manuell ist und von keinem Build ausgelöst wird); Verweis auf das Runbook. Außerdem ein **Bugfix**, siehe unten.
- **`docs/arc42/07-verteilungssicht/01-web-auslieferung.adoc`** — die architektonische Eigenschaft ergänzt: Asset- und Website-Veröffentlichung sind entkoppelt, und die beiden Prefixes `oparl/` und `web-assets/` verhalten sich beim Caching gegensätzlich.
- **`docs/wayfinder/448-abstimmungen-tab-spec.md`** — §7 korrigiert, siehe unten.

## Befunde aus der Live-Prüfung

Beide sind Fallen, wenn man das Gegenteil annimmt:

- **Kein `Cache-Control`.** Die Web-Assets liefern *überhaupt keinen* solchen Header aus. Da die Batch-Dateinamen stabil sind und in-place überschrieben werden, ist nach jedem Upload eine CloudFront-Invalidierung nötig. **Spec §7 behauptete das Gegenteil** — die Begründung dort (»weil der Client per `find` auf `paperId` sucht«) verwechselt die Suche *innerhalb* der Datei mit Edge-Caching. Der inhaltsadressierte `oparl/`-Prefix ist der Sonderfall, der ohne Invalidierung auskommt; das darf nicht auf `web-assets/` übertragen werden. §7 ist entsprechend korrigiert.
- **403 statt 404.** Ein fehlender Key liefert `403` (der Bucket verweigert `ListBucket`). Batch-Dateien existieren nur für Drucksachen *mit* Abstimmungen (122 vs. 486 Paper-Batches) — ein 403 heißt also entweder »nie hochgeladen« oder »korrekterweise leer«, am Statuscode nicht unterscheidbar. Der Client rendert beides als deaktivierten Tab. **Ein vergessener Upload bleibt damit unbemerkt** und sieht aus wie eine Drucksache ohne Abstimmungen.

## Nebenbefund: `generate-paper-votings` stürzte ab

Das in `HOWTO.md` dokumentierte Kommando vergibt `-R=data`, der Writer listet aber das *Output*-Verzeichnis, um verwaiste Batches zu entfernen (`paper-votings-writer.ts:31`, `Deno.readDirSync`). Es schrieb alle 122 Dateien und beendete sich dann mit `NotCapable` und Fehlercode. Da das Runbook genau dieses Kommando vorschreibt, ist der Fix hier mit drin: `-R=data,output/paper-votings`.

## Scope

Bewusste Entscheidung mit dem Maintainer: **erst dokumentieren, später skripten**. Das Skripten des Uploads (inkl. explizitem `Cache-Control`, automatischer Invalidierung und Löschen verwaister Objekte) ist als #463 angelegt.

## Prüfung

- `deno fmt --check`, `deno lint`, `deno check src/`, `deno test` (12 Suites / 129 Steps) — grün.
- `npm run format:check`, `npm test` (74 Tests) — grün.
- Generator lokal geprüft: deterministisch (zweiter Lauf ohne Diff), Stichproben `239123` (cross-period, 2 Perioden) und `243686` (Mehrfach-Scan, 2 Zeilen, nicht dedupliziert).
- Alle Faktenbehauptungen des Runbooks gegen Quelle bzw. Live-Distribution verifiziert.

Reine Doku-Änderung, kein Produktivcode berührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented a maintainer-only manual process to publish runtime web assets to S3 with CloudFront invalidation, explicitly separated from automated website deployments.
  * Added step-by-step guidance for publishing `web-assets/` (including `paper-votings`), covering regeneration of deterministic outputs, overwriting in-place, removing stale batches, verification checks, expected failure behavior (e.g., silent UI issues), and noted known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->