### PR TITLE
feat(paper-consultations): link Beratungen timeline to council session pages

### DIFF
--- a/astro/src/pages/paper/index.astro
+++ b/astro/src/pages/paper/index.astro
@@ -107,8 +107,10 @@ import Layout from '@layouts/Layout.astro';
                   >
                   </div>
                 </div>
-                <div
-                  class="timeline-end timeline-box mt-5 ms-3 w-full space-y-2"
+                <a
+                  class="timeline-end timeline-box mt-5 ms-3 block w-full space-y-2"
+                  :class="consultation.sessionId ? 'hover:bg-base-200 hover:cursor-pointer' : ''"
+                  :href="consultation.sessionId ? `/pp/${consultation.parliamentPeriodId}/session/${consultation.sessionId}/` : null"
                 >
                   <div class="text-base-content/70 space-x-1">
                     <span>TOP</span>
@@ -121,7 +123,7 @@ import Layout from '@layouts/Layout.astro';
                       class="badge badge-neutral badge-sm"
                       x-text="consultation.result"></span>
                   </div>
-                </div>
+                </a>
                 <hr x-show="index < paper.consultations.length - 1" />
               </li>
             </template>
@@ -255,6 +257,8 @@ import Layout from '@layouts/Layout.astro';
     organization: string;
     agendaItem: string | null;
     result: string | null;
+    parliamentPeriodId?: string;
+    sessionId?: string;
   };
 
   type Paper = {

--- a/astro/src/pages/paper/index.astro
+++ b/astro/src/pages/paper/index.astro
@@ -107,23 +107,45 @@ import Layout from '@layouts/Layout.astro';
                   >
                   </div>
                 </div>
-                <a
-                  class="timeline-end timeline-box mt-5 ms-3 block w-full space-y-2"
-                  :class="consultation.sessionId ? 'hover:bg-base-200 hover:cursor-pointer' : ''"
-                  :href="consultation.sessionId ? `/pp/${consultation.parliamentPeriodId}/session/${consultation.sessionId}/` : null"
+                <template
+                  x-if="consultation.parliamentPeriodId && consultation.sessionId"
                 >
-                  <div class="text-base-content/70 space-x-1">
-                    <span>TOP</span>
-                    <span x-text="consultation.agendaItem"></span>
+                  <a
+                    class="timeline-end timeline-box mt-5 ms-3 block w-full space-y-2 hover:bg-base-200 hover:cursor-pointer"
+                    :href="`/pp/${consultation.parliamentPeriodId}/session/${consultation.sessionId}/`"
+                  >
+                    <div class="text-base-content/70 space-x-1">
+                      <span>TOP</span>
+                      <span x-text="consultation.agendaItem"></span>
+                    </div>
+                    <div class="text-base" x-text="consultation.organization">
+                    </div>
+                    <div x-show="consultation.result">
+                      <span
+                        class="badge badge-neutral badge-sm"
+                        x-text="consultation.result"></span>
+                    </div>
+                  </a>
+                </template>
+                <template
+                  x-if="!(consultation.parliamentPeriodId && consultation.sessionId)"
+                >
+                  <div
+                    class="timeline-end timeline-box mt-5 ms-3 w-full space-y-2"
+                  >
+                    <div class="text-base-content/70 space-x-1">
+                      <span>TOP</span>
+                      <span x-text="consultation.agendaItem"></span>
+                    </div>
+                    <div class="text-base" x-text="consultation.organization">
+                    </div>
+                    <div x-show="consultation.result">
+                      <span
+                        class="badge badge-neutral badge-sm"
+                        x-text="consultation.result"></span>
+                    </div>
                   </div>
-                  <div class="text-base" x-text="consultation.organization">
-                  </div>
-                  <div x-show="consultation.result">
-                    <span
-                      class="badge badge-neutral badge-sm"
-                      x-text="consultation.result"></span>
-                  </div>
-                </a>
+                </template>
                 <hr x-show="index < paper.consultations.length - 1" />
               </li>
             </template>

--- a/docker/generate-paper-assets.Dockerfile
+++ b/docker/generate-paper-assets.Dockerfile
@@ -11,10 +11,11 @@ RUN deno install --entrypoint src/scripts/generate-paper-assets/index.ts --unsta
 RUN deno cache src/scripts/generate-paper-assets/index.ts --unstable-sloppy-imports
 
 CMD ["run", \
-        "-R=/app/oparl,/app/papers", \
+        "-R=/app/oparl,/app/papers,/app/data", \
         "-W=/app/generated", \
         "-E=OPARL_COUNCIL_ORGANIZATION_ID", \
         "src/scripts/generate-paper-assets/index.ts", \
         "-r=./oparl", \
         "-p=./papers", \
+        "-d=./data", \
         "-o=./generated"]

--- a/docs/guides/HOWTO.md
+++ b/docs/guides/HOWTO.md
@@ -161,8 +161,13 @@ docker run \
   -v $(pwd)/output/papers:/app/papers:ro \
   -v $(pwd)/data/papers:/app/generated \
   -v $(pwd)/output/ratsinfosystem:/app/oparl:ro \
+  -v $(pwd)/data:/app/data:ro \
   srw-generate-paper-assets
 ```
+
+The mounted `data` directory holds the parliament period registries. It lets the
+generator link consultations to their session pages when a session exists for the
+meeting's date.
 
 
 ### Generate OParl derivates

--- a/docs/guides/HOWTO.md
+++ b/docs/guides/HOWTO.md
@@ -154,10 +154,13 @@ This tool converts OParl data into the internal paper asset format and generates
 docker build -t srw-generate-paper-assets -f docker/generate-paper-assets.Dockerfile .
 ```
 
+The council organization id is read from the `OPARL_COUNCIL_ORGANIZATION_ID` environment variable (e.g. `https://ratsinfo.magdeburg.de/oparl/bodies/0001/organizations/gr/1`). It is used to link consultations to their session pages only for council (Stadtrat) meetings.
+
 #### Run the docker container
 ```shell
 docker run \
   --rm \
+  -e OPARL_COUNCIL_ORGANIZATION_ID=https://ratsinfo.magdeburg.de/oparl/bodies/0001/organizations/gr/1 \
   -v $(pwd)/output/papers:/app/papers:ro \
   -v $(pwd)/data/papers:/app/generated \
   -v $(pwd)/output/ratsinfosystem:/app/oparl:ro \
@@ -166,8 +169,8 @@ docker run \
 ```
 
 The mounted `data` directory holds the parliament period registries. It lets the
-generator link consultations to their session pages when a session exists for the
-meeting's date.
+generator link consultations to their session pages when a council session exists
+for the meeting's date.
 
 
 ### Generate OParl derivates

--- a/src/scripts/generate-paper-assets/acceptance-tests/consultation-linking.test.ts
+++ b/src/scripts/generate-paper-assets/acceptance-tests/consultation-linking.test.ts
@@ -16,13 +16,19 @@ import { PaperAssetsWriter } from '../paper-assets-writer.ts';
 import { PaperGraphAssetsWriter } from '../paper-graph-assets-writer.ts';
 import { SessionIndex, SessionIndexStore } from '../session-index.ts';
 
-const MEETING_WITH_SESSION_PAGE = 'http://example.com/oparl/meetings/1';
-const MEETING_WITHOUT_SESSION_PAGE = 'http://example.com/oparl/meetings/2';
-const ORGANIZATION = 'http://example.com/oparl/organizations/1';
-const AGENDA_ITEM_LINKED = 'http://example.com/oparl/agendaItems/1';
-const AGENDA_ITEM_UNLINKED = 'http://example.com/oparl/agendaItems/2';
+const COUNCIL_ORGANIZATION = 'http://example.com/oparl/organizations/council';
+const MAYOR_ORGANIZATION = 'http://example.com/oparl/organizations/mayor';
+
+const COUNCIL_MEETING_ON_SESSION_DATE = 'http://example.com/oparl/meetings/1';
+const COUNCIL_MEETING_WITHOUT_SESSION_PAGE = 'http://example.com/oparl/meetings/2';
+const MAYOR_MEETING_ON_SESSION_DATE = 'http://example.com/oparl/meetings/3';
+
+const AGENDA_ITEM_COUNCIL_LINKED = 'http://example.com/oparl/agendaItems/1';
+const AGENDA_ITEM_COUNCIL_UNLINKED = 'http://example.com/oparl/agendaItems/2';
+const AGENDA_ITEM_MAYOR = 'http://example.com/oparl/agendaItems/3';
 
 const SESSION_DATE = '2024-07-08';
+const OTHER_DATE = '2024-06-03';
 const PARLIAMENT_PERIOD_ID = 'magdeburg-8';
 
 class MockPaperFilesStore implements PaperFilesStore {
@@ -31,8 +37,9 @@ class MockPaperFilesStore implements PaperFilesStore {
 
 class MockOparlObjectsStore implements OparlObjectsStore {
   loadAgendaItems = (): OparlAgendaItem[] => [
-    this.agendaItem(AGENDA_ITEM_LINKED, '5.1'),
-    this.agendaItem(AGENDA_ITEM_UNLINKED, '5.2'),
+    this.agendaItem(AGENDA_ITEM_COUNCIL_LINKED, '5.1'),
+    this.agendaItem(AGENDA_ITEM_COUNCIL_UNLINKED, '5.2'),
+    this.agendaItem(AGENDA_ITEM_MAYOR, '5.3'),
   ];
 
   loadConsultations = (): OparlConsultation[] => [];
@@ -40,12 +47,14 @@ class MockOparlObjectsStore implements OparlObjectsStore {
   loadFiles = (): OparlFile[] => [];
 
   loadMeetings = (): OparlMeeting[] => [
-    this.meeting(MEETING_WITH_SESSION_PAGE, `${SESSION_DATE}T15:00:00+02:00`),
-    this.meeting(MEETING_WITHOUT_SESSION_PAGE, '2024-06-03T15:00:00+02:00'),
+    this.meeting(COUNCIL_MEETING_ON_SESSION_DATE, `${SESSION_DATE}T15:00:00+02:00`, COUNCIL_ORGANIZATION),
+    this.meeting(COUNCIL_MEETING_WITHOUT_SESSION_PAGE, `${OTHER_DATE}T15:00:00+02:00`, COUNCIL_ORGANIZATION),
+    this.meeting(MAYOR_MEETING_ON_SESSION_DATE, `${SESSION_DATE}T10:00:00+02:00`, MAYOR_ORGANIZATION),
   ];
 
   loadOrganizations = (): OparlOrganization[] => [
-    { id: ORGANIZATION, type: 'https://schema.oparl.org/1.1/Organization', name: 'Stadtrat' },
+    { id: COUNCIL_ORGANIZATION, type: 'https://schema.oparl.org/1.1/Organization', name: 'Stadtrat' },
+    { id: MAYOR_ORGANIZATION, type: 'https://schema.oparl.org/1.1/Organization', name: 'Oberbürgermeisterin' },
   ];
 
   loadPapers = (): OparlPaper[] => [
@@ -54,27 +63,28 @@ class MockOparlObjectsStore implements OparlObjectsStore {
       type: 'https://schema.oparl.org/1.1/Paper',
       name: 'Paper 1',
       consultation: [
-        this.consultation(MEETING_WITH_SESSION_PAGE, AGENDA_ITEM_LINKED),
-        this.consultation(MEETING_WITHOUT_SESSION_PAGE, AGENDA_ITEM_UNLINKED),
+        this.consultation(COUNCIL_MEETING_ON_SESSION_DATE, COUNCIL_ORGANIZATION, AGENDA_ITEM_COUNCIL_LINKED),
+        this.consultation(COUNCIL_MEETING_WITHOUT_SESSION_PAGE, COUNCIL_ORGANIZATION, AGENDA_ITEM_COUNCIL_UNLINKED),
+        this.consultation(MAYOR_MEETING_ON_SESSION_DATE, MAYOR_ORGANIZATION, AGENDA_ITEM_MAYOR),
       ],
     },
   ];
 
-  private meeting(id: string, start: string): OparlMeeting {
-    return { id, type: 'https://schema.oparl.org/1.1/Meeting', name: 'Sitzung', start };
+  private meeting(id: string, start: string, organization: string): OparlMeeting {
+    return { id, type: 'https://schema.oparl.org/1.1/Meeting', name: 'Sitzung', start, organization: [organization] };
   }
 
   private agendaItem(id: string, number: string): OparlAgendaItem {
     return { id, type: 'https://schema.oparl.org/1.1/AgendaItem', name: 'TOP', order: 0, number };
   }
 
-  private consultation(meeting: string, agendaItem: string): OparlConsultation {
+  private consultation(meeting: string, organization: string, agendaItem: string): OparlConsultation {
     return {
       id: `${meeting}-consultation`,
       type: 'https://schema.oparl.org/1.1/Consultation',
       name: 'Beratung',
       meeting,
-      organization: [ORGANIZATION],
+      organization: [organization],
       agendaItem,
     };
   }
@@ -100,32 +110,33 @@ class NoopPaperGraphAssetsWriter implements PaperGraphAssetsWriter {
 }
 
 describe('Linking consultations to session pages', () => {
-  it('attaches the parliament period and session id when the meeting date has a session page', () => {
-    const consultations = generateConsultations({
-      [SESSION_DATE]: { parliamentPeriodId: PARLIAMENT_PERIOD_ID, sessionId: SESSION_DATE },
-    });
-
-    const linked = consultations.find((consultation) => consultation.agendaItem === '5.1')!;
+  it('attaches the parliament period and session id when a council meeting has a session page', () => {
+    const linked = generateConsultations().find((consultation) => consultation.agendaItem === '5.1')!;
     assertEquals(linked.parliamentPeriodId, PARLIAMENT_PERIOD_ID);
     assertEquals(linked.sessionId, SESSION_DATE);
   });
 
-  it('leaves consultations without a matching session page unlinked', () => {
-    const consultations = generateConsultations({
-      [SESSION_DATE]: { parliamentPeriodId: PARLIAMENT_PERIOD_ID, sessionId: SESSION_DATE },
-    });
-
-    const unlinked = consultations.find((consultation) => consultation.agendaItem === '5.2')!;
+  it('leaves council consultations without a matching session page unlinked', () => {
+    const unlinked = generateConsultations().find((consultation) => consultation.agendaItem === '5.2')!;
     assertEquals(unlinked.parliamentPeriodId, undefined);
     assertEquals(unlinked.sessionId, undefined);
   });
 
-  function generateConsultations(sessionIndex: SessionIndex): PaperConsultationDto[] {
+  it('does not link non-council meetings that merely share a session date', () => {
+    const mayorConsultation = generateConsultations().find((consultation) => consultation.agendaItem === '5.3')!;
+    assertEquals(mayorConsultation.parliamentPeriodId, undefined);
+    assertEquals(mayorConsultation.sessionId, undefined);
+  });
+
+  function generateConsultations(): PaperConsultationDto[] {
     const writer = new CapturingPaperAssetsWriter();
     const generator = new PaperAssetsGenerator(
       new MockPaperFilesStore(),
       new MockOparlObjectsStore(),
-      new MockSessionIndexStore(sessionIndex),
+      new MockSessionIndexStore({
+        [SESSION_DATE]: { parliamentPeriodId: PARLIAMENT_PERIOD_ID, sessionId: SESSION_DATE },
+      }),
+      COUNCIL_ORGANIZATION,
       writer,
       new NoopPaperGraphAssetsWriter(),
     );

--- a/src/scripts/generate-paper-assets/acceptance-tests/consultation-linking.test.ts
+++ b/src/scripts/generate-paper-assets/acceptance-tests/consultation-linking.test.ts
@@ -1,0 +1,135 @@
+import { describe, it } from '@std/testing/bdd';
+import { assertEquals } from '@std/assert';
+import { PaperAssetsGenerator } from '../paper-assets-generator.ts';
+import { OparlObjectsStore } from '../../shared/oparl/oparl-objects-store.ts';
+import {
+  OparlAgendaItem,
+  OparlConsultation,
+  OparlFile,
+  OparlMeeting,
+  OparlOrganization,
+  OparlPaper,
+} from '@srw-astro/models/oparl';
+import { PaperAssetDto, PaperConsultationDto, PaperGraphAssetDto } from '../model.ts';
+import { PaperFilesStore } from '../paper-files-store.ts';
+import { PaperAssetsWriter } from '../paper-assets-writer.ts';
+import { PaperGraphAssetsWriter } from '../paper-graph-assets-writer.ts';
+import { SessionIndex, SessionIndexStore } from '../session-index.ts';
+
+const MEETING_WITH_SESSION_PAGE = 'http://example.com/oparl/meetings/1';
+const MEETING_WITHOUT_SESSION_PAGE = 'http://example.com/oparl/meetings/2';
+const ORGANIZATION = 'http://example.com/oparl/organizations/1';
+const AGENDA_ITEM_LINKED = 'http://example.com/oparl/agendaItems/1';
+const AGENDA_ITEM_UNLINKED = 'http://example.com/oparl/agendaItems/2';
+
+const SESSION_DATE = '2024-07-08';
+const PARLIAMENT_PERIOD_ID = 'magdeburg-8';
+
+class MockPaperFilesStore implements PaperFilesStore {
+  getFileSize = (_fileId: number): number | null => null;
+}
+
+class MockOparlObjectsStore implements OparlObjectsStore {
+  loadAgendaItems = (): OparlAgendaItem[] => [
+    this.agendaItem(AGENDA_ITEM_LINKED, '5.1'),
+    this.agendaItem(AGENDA_ITEM_UNLINKED, '5.2'),
+  ];
+
+  loadConsultations = (): OparlConsultation[] => [];
+
+  loadFiles = (): OparlFile[] => [];
+
+  loadMeetings = (): OparlMeeting[] => [
+    this.meeting(MEETING_WITH_SESSION_PAGE, `${SESSION_DATE}T15:00:00+02:00`),
+    this.meeting(MEETING_WITHOUT_SESSION_PAGE, '2024-06-03T15:00:00+02:00'),
+  ];
+
+  loadOrganizations = (): OparlOrganization[] => [
+    { id: ORGANIZATION, type: 'https://schema.oparl.org/1.1/Organization', name: 'Stadtrat' },
+  ];
+
+  loadPapers = (): OparlPaper[] => [
+    {
+      id: 'http://example.com/oparl/papers/1',
+      type: 'https://schema.oparl.org/1.1/Paper',
+      name: 'Paper 1',
+      consultation: [
+        this.consultation(MEETING_WITH_SESSION_PAGE, AGENDA_ITEM_LINKED),
+        this.consultation(MEETING_WITHOUT_SESSION_PAGE, AGENDA_ITEM_UNLINKED),
+      ],
+    },
+  ];
+
+  private meeting(id: string, start: string): OparlMeeting {
+    return { id, type: 'https://schema.oparl.org/1.1/Meeting', name: 'Sitzung', start };
+  }
+
+  private agendaItem(id: string, number: string): OparlAgendaItem {
+    return { id, type: 'https://schema.oparl.org/1.1/AgendaItem', name: 'TOP', order: 0, number };
+  }
+
+  private consultation(meeting: string, agendaItem: string): OparlConsultation {
+    return {
+      id: `${meeting}-consultation`,
+      type: 'https://schema.oparl.org/1.1/Consultation',
+      name: 'Beratung',
+      meeting,
+      organization: [ORGANIZATION],
+      agendaItem,
+    };
+  }
+}
+
+class MockSessionIndexStore implements SessionIndexStore {
+  constructor(private readonly sessionIndex: SessionIndex) {
+  }
+
+  loadSessionIndex = (): SessionIndex => this.sessionIndex;
+}
+
+class CapturingPaperAssetsWriter implements PaperAssetsWriter {
+  consultations: PaperConsultationDto[] = [];
+
+  writePaperAssets(assets: PaperAssetDto[]): void {
+    this.consultations = assets.flatMap((asset) => asset.papers).flatMap((paper) => paper.consultations);
+  }
+}
+
+class NoopPaperGraphAssetsWriter implements PaperGraphAssetsWriter {
+  writePaperGraphAssets(_assets: PaperGraphAssetDto[]): void {}
+}
+
+describe('Linking consultations to session pages', () => {
+  it('attaches the parliament period and session id when the meeting date has a session page', () => {
+    const consultations = generateConsultations({
+      [SESSION_DATE]: { parliamentPeriodId: PARLIAMENT_PERIOD_ID, sessionId: SESSION_DATE },
+    });
+
+    const linked = consultations.find((consultation) => consultation.agendaItem === '5.1')!;
+    assertEquals(linked.parliamentPeriodId, PARLIAMENT_PERIOD_ID);
+    assertEquals(linked.sessionId, SESSION_DATE);
+  });
+
+  it('leaves consultations without a matching session page unlinked', () => {
+    const consultations = generateConsultations({
+      [SESSION_DATE]: { parliamentPeriodId: PARLIAMENT_PERIOD_ID, sessionId: SESSION_DATE },
+    });
+
+    const unlinked = consultations.find((consultation) => consultation.agendaItem === '5.2')!;
+    assertEquals(unlinked.parliamentPeriodId, undefined);
+    assertEquals(unlinked.sessionId, undefined);
+  });
+
+  function generateConsultations(sessionIndex: SessionIndex): PaperConsultationDto[] {
+    const writer = new CapturingPaperAssetsWriter();
+    const generator = new PaperAssetsGenerator(
+      new MockPaperFilesStore(),
+      new MockOparlObjectsStore(),
+      new MockSessionIndexStore(sessionIndex),
+      writer,
+      new NoopPaperGraphAssetsWriter(),
+    );
+    generator.generatePaperAssets();
+    return writer.consultations;
+  }
+});

--- a/src/scripts/generate-paper-assets/acceptance-tests/scenario.test.ts
+++ b/src/scripts/generate-paper-assets/acceptance-tests/scenario.test.ts
@@ -181,6 +181,7 @@ describe('Generating paper assets', () => {
       paperFilesStore,
       oparlObjectsStore,
       sessionIndexStore,
+      'http://example.com/oparl/organizations/council',
       paperAssetsWriter,
       paperGraphAssetsWriter,
     );

--- a/src/scripts/generate-paper-assets/acceptance-tests/scenario.test.ts
+++ b/src/scripts/generate-paper-assets/acceptance-tests/scenario.test.ts
@@ -14,6 +14,7 @@ import {
 import { PaperAssetDto, PaperGraphAssetDto } from '../model.ts';
 import { PaperFilesStore } from '../paper-files-store.ts';
 import { PaperGraphAssetsWriter } from '../paper-graph-assets-writer.ts';
+import { SessionIndex, SessionIndexStore } from '../session-index.ts';
 
 class MockPaperFilesStore implements PaperFilesStore {
   getFileSize(_fileId: number): number | null {
@@ -89,6 +90,13 @@ class MockOparlObjectsStore implements OparlObjectsStore {
   }
 }
 
+class MockSessionIndexStore implements SessionIndexStore {
+  constructor(private readonly sessionIndex: SessionIndex = {}) {
+  }
+
+  loadSessionIndex = (): SessionIndex => this.sessionIndex;
+}
+
 class MockPaperAssetsWriter implements PaperAssetsWriter {
   papersWritten = 0;
   paperAssetsWritten = 0;
@@ -112,6 +120,7 @@ class MockPaperGraphAssetsWriter implements PaperGraphAssetsWriter {
 describe('Generating paper assets', () => {
   let paperFilesStore: MockPaperFilesStore;
   let oparlObjectsStore: MockOparlObjectsStore;
+  let sessionIndexStore: MockSessionIndexStore;
   let paperAssetsWriter: MockPaperAssetsWriter;
   let paperGraphAssetsWriter: MockPaperGraphAssetsWriter;
 
@@ -119,6 +128,7 @@ describe('Generating paper assets', () => {
     // GIVEN
     paperFilesStoreIsAvailable();
     oparlObjectStoreIsAvailable();
+    sessionIndexStoreIsAvailable();
     paperAssetsWriterIsAvailable();
     paperGraphAssetWriterIsAvailable();
 
@@ -134,6 +144,7 @@ describe('Generating paper assets', () => {
     // GIVEN
     paperFilesStoreIsAvailable();
     oparlObjectStoreIsAvailable();
+    sessionIndexStoreIsAvailable();
     paperAssetsWriterIsAvailable();
     paperGraphAssetWriterIsAvailable();
 
@@ -153,6 +164,10 @@ describe('Generating paper assets', () => {
     oparlObjectsStore = new MockOparlObjectsStore();
   }
 
+  function sessionIndexStoreIsAvailable(sessionIndex: SessionIndex = {}) {
+    sessionIndexStore = new MockSessionIndexStore(sessionIndex);
+  }
+
   function paperAssetsWriterIsAvailable() {
     paperAssetsWriter = new MockPaperAssetsWriter();
   }
@@ -165,6 +180,7 @@ describe('Generating paper assets', () => {
     const generator = new PaperAssetsGenerator(
       paperFilesStore,
       oparlObjectsStore,
+      sessionIndexStore,
       paperAssetsWriter,
       paperGraphAssetsWriter,
     );

--- a/src/scripts/generate-paper-assets/cli.ts
+++ b/src/scripts/generate-paper-assets/cli.ts
@@ -4,24 +4,29 @@ export type GeneratePaperAssetsArgs = {
   help: boolean;
   ratsinfoDir: string;
   papersDir: string;
+  dataDir: string;
   outputDir: string;
 };
 
 export function parseArgs(args: string[]): GeneratePaperAssetsArgs {
   return stdCliParseArgs(args, {
     boolean: ['help'],
-    string: ['ratsinfoDir', 'papers-dir', 'output-dir'],
+    string: ['ratsinfoDir', 'papers-dir', 'data-dir', 'output-dir'],
     alias: {
       help: 'h',
       'ratsinfo-dir': ['r', 'ratsinfoDir'],
       'papers-dir': ['p', 'papersDir'],
+      'data-dir': ['d', 'dataDir'],
       'output-dir': ['o', 'outputDir'],
+    },
+    default: {
+      'data-dir': 'data/',
     },
   }) as GeneratePaperAssetsArgs;
 }
 
 export function checkArgs(args: GeneratePaperAssetsArgs) {
-  const { ratsinfoDir, papersDir, outputDir } = args;
+  const { ratsinfoDir, papersDir, dataDir, outputDir } = args;
 
   if (!ratsinfoDir) {
     console.error('Missing ratsinfo directory. See --help for usage.');
@@ -33,6 +38,11 @@ export function checkArgs(args: GeneratePaperAssetsArgs) {
     Deno.exit(1);
   }
 
+  if (!dataDir) {
+    console.error('Missing data directory. See --help for usage.');
+    Deno.exit(1);
+  }
+
   if (!outputDir) {
     console.error('Missing output directory. See --help for usage.');
     Deno.exit(1);
@@ -41,10 +51,12 @@ export function checkArgs(args: GeneratePaperAssetsArgs) {
 
 export function printHelpText() {
   console.log(`
-Usage: deno run index.ts -r <ratsinfo-dir> -p <papers-dir> -o <output-dir>
+Usage: deno run index.ts -r <ratsinfo-dir> -p <papers-dir> [-d <data-dir>] -o <output-dir>
 -h, --help                  Show this help message and exit.
 -r, --ratsinfo-dir          The directory containing the OParl files (meetings.json, papers.json, files.json).
 -p, --papers-dir            The papers directory. It should contain directories with the paper files per year.
+-d, --data-dir              The data directory containing the parliament period registries. Used to link
+                            consultations to their session pages by date. Default: data/
 -o, --output-dir            The output directory. Json files with the papers data will be written here.
   `);
 }

--- a/src/scripts/generate-paper-assets/env.ts
+++ b/src/scripts/generate-paper-assets/env.ts
@@ -1,0 +1,13 @@
+export type GeneratePaperAssetsEnv = {
+  councilOrganizationId: string;
+};
+
+export function getGeneratePaperAssetsEnvOrExit(): GeneratePaperAssetsEnv {
+  const councilOrganizationId = Deno.env.get('OPARL_COUNCIL_ORGANIZATION_ID');
+  if (!councilOrganizationId) {
+    console.error('Environment variable OPARL_COUNCIL_ORGANIZATION_ID must be set.');
+    Deno.exit(1);
+  }
+
+  return { councilOrganizationId };
+}

--- a/src/scripts/generate-paper-assets/index.ts
+++ b/src/scripts/generate-paper-assets/index.ts
@@ -5,6 +5,7 @@ import { PaperAssetsFileWriter } from './paper-assets-writer.ts';
 import { OparlObjectsFileStore } from '../shared/oparl/oparl-objects-store.ts';
 import { PaperGraphAssetsFileWriter } from './paper-graph-assets-writer.ts';
 import { SessionIndexFileStore } from './session-index.ts';
+import { getGeneratePaperAssetsEnvOrExit } from './env.ts';
 
 const args = parseArgs(Deno.args);
 
@@ -14,6 +15,8 @@ if (args.help) {
 }
 
 checkArgs(args);
+
+const { councilOrganizationId } = getGeneratePaperAssetsEnvOrExit();
 
 const paperFilesStore = new PaperFilesFileStore(args.papersDir);
 const oparlObjectsStore = new OparlObjectsFileStore(args.ratsinfoDir);
@@ -25,6 +28,7 @@ const generator = new PaperAssetsGenerator(
   paperFilesStore,
   oparlObjectsStore,
   sessionIndexStore,
+  councilOrganizationId,
   paperAssetsWriter,
   paperGraphAssetsWriter,
 );

--- a/src/scripts/generate-paper-assets/index.ts
+++ b/src/scripts/generate-paper-assets/index.ts
@@ -4,6 +4,7 @@ import { PaperAssetsGenerator } from './paper-assets-generator.ts';
 import { PaperAssetsFileWriter } from './paper-assets-writer.ts';
 import { OparlObjectsFileStore } from '../shared/oparl/oparl-objects-store.ts';
 import { PaperGraphAssetsFileWriter } from './paper-graph-assets-writer.ts';
+import { SessionIndexFileStore } from './session-index.ts';
 
 const args = parseArgs(Deno.args);
 
@@ -16,12 +17,14 @@ checkArgs(args);
 
 const paperFilesStore = new PaperFilesFileStore(args.papersDir);
 const oparlObjectsStore = new OparlObjectsFileStore(args.ratsinfoDir);
+const sessionIndexStore = new SessionIndexFileStore(args.dataDir);
 const paperAssetsWriter = new PaperAssetsFileWriter(args.outputDir);
 const paperGraphAssetsWriter = new PaperGraphAssetsFileWriter(args.outputDir);
 
 const generator = new PaperAssetsGenerator(
   paperFilesStore,
   oparlObjectsStore,
+  sessionIndexStore,
   paperAssetsWriter,
   paperGraphAssetsWriter,
 );

--- a/src/scripts/generate-paper-assets/model.ts
+++ b/src/scripts/generate-paper-assets/model.ts
@@ -12,6 +12,8 @@ export type PaperConsultationDto = {
   organization: string;
   agendaItem: string | null;
   result: string | null;
+  parliamentPeriodId?: string;
+  sessionId?: string;
 };
 
 export type PaperDto = {

--- a/src/scripts/generate-paper-assets/paper-assets-generator.ts
+++ b/src/scripts/generate-paper-assets/paper-assets-generator.ts
@@ -18,7 +18,7 @@ import {
   OparlAgendaItemsInMemoryRepository,
   OparlAgendaItemsRepository,
 } from '../shared/oparl/oparl-agenda-items-repository.ts';
-import { OparlPaper } from '@srw-astro/models/oparl';
+import { OparlMeeting, OparlPaper } from '@srw-astro/models/oparl';
 import { toPaperBatchNo } from '@srw-astro/models/paper-batch';
 import { createInMemoryPaperGraph } from './paper-graph.ts';
 import { OparlObjectsStore } from '../shared/oparl/oparl-objects-store.ts';
@@ -38,6 +38,7 @@ export class PaperAssetsGenerator {
     private readonly paperFilesStore: PaperFilesStore,
     private readonly oparlObjectsStore: OparlObjectsStore,
     private readonly sessionIndexStore: SessionIndexStore,
+    private readonly councilOrganizationId: string,
     private readonly paperAssetsWriter: PaperAssetsWriter,
     private readonly paperGraphAssetsWriter: PaperGraphAssetsWriter,
   ) {
@@ -150,7 +151,7 @@ export class PaperAssetsGenerator {
           return null;
         }
 
-        const sessionLocation = this.resolveSessionLocation(meeting.start);
+        const sessionLocation = this.resolveSessionLocation(meeting);
 
         return {
           meeting: meeting.name,
@@ -171,12 +172,17 @@ export class PaperAssetsGenerator {
       });
   }
 
-  private resolveSessionLocation(meetingStart: string | undefined): Partial<SessionLocation> {
-    if (!meetingStart) {
+  // A session page only exists for council (Stadtrat) meetings, so a consultation
+  // is only linkable when its meeting belongs to the council organization. Matching
+  // on the meeting date alone would wrongly link non-council meetings (e.g. the
+  // mayor's) that happen to fall on the same day as a council session.
+  private resolveSessionLocation(meeting: OparlMeeting): Partial<SessionLocation> {
+    const isCouncilMeeting = (meeting.organization || []).includes(this.councilOrganizationId);
+    if (!isCouncilMeeting || !meeting.start) {
       return {};
     }
 
-    const meetingDate = meetingStart.split('T')[0];
+    const meetingDate = meeting.start.split('T')[0];
     return this.sessionIndex[meetingDate] ?? {};
   }
 

--- a/src/scripts/generate-paper-assets/paper-assets-generator.ts
+++ b/src/scripts/generate-paper-assets/paper-assets-generator.ts
@@ -24,6 +24,7 @@ import { createInMemoryPaperGraph } from './paper-graph.ts';
 import { OparlObjectsStore } from '../shared/oparl/oparl-objects-store.ts';
 import { PaperAssetsWriter } from './paper-assets-writer.ts';
 import { PaperGraphAssetsWriter } from './paper-graph-assets-writer.ts';
+import { SessionIndex, SessionIndexStore, SessionLocation } from './session-index.ts';
 
 export class PaperAssetsGenerator {
   private readonly meetingsRepository: OparlMeetingsRepository;
@@ -31,10 +32,12 @@ export class PaperAssetsGenerator {
   private readonly organizationsRepository: OparlOrganizationsRepository;
   private readonly agendaItemsRepository: OparlAgendaItemsRepository;
   private readonly filesRepository: OparlFilesRepository;
+  private readonly sessionIndex: SessionIndex;
 
   constructor(
     private readonly paperFilesStore: PaperFilesStore,
     private readonly oparlObjectsStore: OparlObjectsStore,
+    private readonly sessionIndexStore: SessionIndexStore,
     private readonly paperAssetsWriter: PaperAssetsWriter,
     private readonly paperGraphAssetsWriter: PaperGraphAssetsWriter,
   ) {
@@ -43,6 +46,7 @@ export class PaperAssetsGenerator {
     this.organizationsRepository = new OparlOrganizationsInMemoryRepository(this.oparlObjectsStore.loadOrganizations());
     this.agendaItemsRepository = new OparlAgendaItemsInMemoryRepository(this.oparlObjectsStore.loadAgendaItems());
     this.filesRepository = new OparlFilesInMemoryRepository(this.oparlObjectsStore.loadFiles(), this.papersRepository);
+    this.sessionIndex = this.sessionIndexStore.loadSessionIndex();
   }
 
   public generatePaperAssets() {
@@ -146,6 +150,8 @@ export class PaperAssetsGenerator {
           return null;
         }
 
+        const sessionLocation = this.resolveSessionLocation(meeting.start);
+
         return {
           meeting: meeting.name,
           date: meeting.start || null,
@@ -153,6 +159,7 @@ export class PaperAssetsGenerator {
           organization: organization.name,
           agendaItem: agendaItem.number || null,
           result: agendaItem.result || null,
+          ...sessionLocation,
         };
       })
       .filter((consultation): consultation is PaperConsultationDto => consultation !== null)
@@ -162,6 +169,15 @@ export class PaperAssetsGenerator {
         if (!b.date) return -1;
         return a.date.localeCompare(b.date);
       });
+  }
+
+  private resolveSessionLocation(meetingStart: string | undefined): Partial<SessionLocation> {
+    if (!meetingStart) {
+      return {};
+    }
+
+    const meetingDate = meetingStart.split('T')[0];
+    return this.sessionIndex[meetingDate] ?? {};
   }
 
   private getFiles(paper: OparlPaper) {

--- a/src/scripts/generate-paper-assets/session-index.ts
+++ b/src/scripts/generate-paper-assets/session-index.ts
@@ -1,0 +1,56 @@
+import * as path from '@std/path';
+import { Registry } from '@srw-astro/models/registry';
+
+export type SessionLocation = {
+  parliamentPeriodId: string;
+  sessionId: string;
+};
+
+// Maps a session date (YYYY-MM-DD) to the parliament period and session it
+// belongs to. Session dates are unique across all periods, so the date is a
+// safe key for resolving whether a consultation has a session page.
+export type SessionIndex = { [sessionDate: string]: SessionLocation };
+
+export interface SessionIndexStore {
+  loadSessionIndex(): SessionIndex;
+}
+
+export class SessionIndexFileStore implements SessionIndexStore {
+  constructor(private readonly dataDir: string) {
+  }
+
+  public loadSessionIndex(): SessionIndex {
+    const sessionIndex: SessionIndex = {};
+
+    for (const entry of Deno.readDirSync(this.dataDir)) {
+      if (!entry.isDirectory) {
+        continue;
+      }
+
+      const registry = this.readRegistry(path.join(this.dataDir, entry.name, 'registry.json'));
+      if (!registry) {
+        continue;
+      }
+
+      for (const session of registry.sessions) {
+        sessionIndex[session.date] = {
+          parliamentPeriodId: registry.id,
+          sessionId: session.id,
+        };
+      }
+    }
+
+    return sessionIndex;
+  }
+
+  private readRegistry(filePath: string): Registry | null {
+    try {
+      return JSON.parse(Deno.readTextFileSync(filePath)) as Registry;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Closes #466

## What

Consultation entries in the **Beratungen** tab of a paper's detail page (`/paper?paperId=…`) now link to the corresponding session page when the consultation took place in a council (Stadtrat) session. Non-linkable entries stay as plain text.

## How

- **Server-side resolution** in `generate-paper-assets`: a new `SessionIndexFileStore` builds a `date → { parliamentPeriodId, sessionId }` index from the parliament period registries. Each consultation's meeting date is matched against it, and `parliamentPeriodId`/`sessionId` are attached to `PaperConsultationDto` on a hit.
- **Council-only linking**: matching on date alone wrongly linked non-council meetings (e.g. "Die Oberbürgermeisterin") that happened to fall on the same day as a Stadtrat session. Linking is now gated on the consultation's **meeting belonging to the council organization**, mirroring how `generate-oparl-derivatives` identifies council meetings. The council org id is read from the `OPARL_COUNCIL_ORGANIZATION_ID` env var.
- **Client rendering** ([paper/index.astro](astro/src/pages/paper/index.astro)): the timeline entry renders as an `<a>` to `/pp/{period}/session/{date}/` (with hover styling) only when a `sessionId` is present, otherwise plain text.

## Testing

- New `consultation-linking.test.ts` covers the hit case, the date-miss case, and the regression case (non-council meeting sharing a session date).
- Full suites green: `deno test` (13 files / 132 steps), `npm test` (74 tests), `astro check` (0 errors), plus fmt/lint.
- Regenerated the paper assets and verified paper 248812: both consultations (Oberbürgermeisterin 2026-05-26, Jugendhilfeausschuss 2026-06-11) are correctly unlinked. Across the full set, all 8616 linked consultations belong to the Stadtrat.

## Notes

- `generate-paper-assets` now **requires** `OPARL_COUNCIL_ORGANIZATION_ID` (consistent with `generate-oparl-derivatives`); the Dockerfile already declared it and HOWTO.md is updated to pass it. A new `-d/--data-dir` flag (default `data/`) feeds the registries in.
- Regenerated `data/papers/*` assets are intentionally **not** included in this PR; they'll be regenerated/published through the usual manual path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consultation “end” content now renders as a clickable link only when session details are available.
  * Paper asset generation can enrich council consultations with matching session links using meeting dates.
  * Added a `--data-dir` (`-d`) option (default: `data/`) to locate session registries.
* **Documentation**
  * Updated “Generate paper assets” guide to require the council identifier and mount the `data` directory.
* **Bug Fixes**
  * Prevents incorrect session linking for missing start/session data and non-council meetings.
* **Tests**
  * Added acceptance coverage for linked, unlinked, and non-council consultation behavior.
* **Chores**
  * Adjusted Docker input paths to include `data/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->